### PR TITLE
when package deactivate prompt user reload

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -18,6 +18,9 @@ class I18N
   activate: (state) ->
     setTimeout(@delay, 0)
 
+  deactivate: () ->
+    Util.promptUserReloadAtom("Reload Atom to clear translation.")
+
   delay: () =>
     Menu.localize(@defM)
     ContextMenu.localize(@defC)
@@ -32,7 +35,7 @@ class I18N
         option.value is newLocale
       newLangauge = if newOption then newOption.description else newLocale
 
-      Util.promtReloadAtom("Reload Atom to translate into `#{newLangauge}`.")
+      Util.promptUserReloadAtom("Reload Atom to translate into `#{newLangauge}`.")
 
 
 module.exports = window.I18N = new I18N()

--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -1,6 +1,6 @@
 class Util
 
-  @promtReloadAtom: (msg = "Reload Atom for localization.") ->
+  @promptUserReloadAtom: (msg = "Reload Atom for localization.") ->
     buttons = [{
       text: 'Reload',
       onDidClick: -> atom.reload()


### PR DESCRIPTION
related issue #8 

- as title
- use `atom.reload()` which is faster than restart Atom
- also fix function name typo: promtReloadAtom -> promptUserReloadAtom