### PR TITLE
cleanup non-English words in menu_linux.cson

### DIFF
--- a/def/ar/menu_linux.cson
+++ b/def/ar/menu_linux.cson
@@ -242,9 +242,9 @@ Menu:
     value: "Find(&I)"
     submenu:
       "Find in Buffer":
-        value: "検索"
+        value: "Find in Buffer"
       "Replace in Buffer":
-        value: "置換"
+        value: "Replace in Buffer"
       "Select Next":
         value: "Select Next"
       "Select All":

--- a/def/de/menu_linux.cson
+++ b/def/de/menu_linux.cson
@@ -242,9 +242,9 @@ Menu:
     value: "Find(&I)"
     submenu:
       "Find in Buffer":
-        value: "検索"
+        value: "Find in Buffer"
       "Replace in Buffer":
-        value: "置換"
+        value: "Replace in Buffer"
       "Select Next":
         value: "Select Next"
       "Select All":

--- a/def/fr/menu_linux.cson
+++ b/def/fr/menu_linux.cson
@@ -242,9 +242,9 @@ Menu:
     value: "Find(&I)"
     submenu:
       "Find in Buffer":
-        value: "検索"
+        value: "Find in Buffer"
       "Replace in Buffer":
-        value: "置換"
+        value: "Replace in Buffer"
       "Select Next":
         value: "Select Next"
       "Select All":

--- a/def/hi/menu_linux.cson
+++ b/def/hi/menu_linux.cson
@@ -242,9 +242,9 @@ Menu:
     value: "Find(&I)"
     submenu:
       "Find in Buffer":
-        value: "検索"
+        value: "Find in Buffer"
       "Replace in Buffer":
-        value: "置換"
+        value: "Replace in Buffer"
       "Select Next":
         value: "Select Next"
       "Select All":

--- a/def/nl/menu_linux.cson
+++ b/def/nl/menu_linux.cson
@@ -242,9 +242,9 @@ Menu:
     value: "Find(&I)"
     submenu:
       "Find in Buffer":
-        value: "検索"
+        value: "Find in Buffer"
       "Replace in Buffer":
-        value: "置換"
+        value: "Replace in Buffer"
       "Select Next":
         value: "Select Next"
       "Select All":

--- a/def/pt-br/menu_linux.cson
+++ b/def/pt-br/menu_linux.cson
@@ -242,9 +242,9 @@ Menu:
     value: "Find(&I)"
     submenu:
       "Find in Buffer":
-        value: "検索"
+        value: "Find in Buffer"
       "Replace in Buffer":
-        value: "置換"
+        value: "Replace in Buffer"
       "Select Next":
         value: "Select Next"
       "Select All":

--- a/def/template/menu_linux.cson
+++ b/def/template/menu_linux.cson
@@ -242,9 +242,9 @@ Menu:
     value: "Find(&I)"
     submenu:
       "Find in Buffer":
-        value: "検索"
+        value: "Find in Buffer"
       "Replace in Buffer":
-        value: "置換"
+        value: "Replace in Buffer"
       "Select Next":
         value: "Select Next"
       "Select All":


### PR DESCRIPTION
related issue #16 

cleanup non-English words in menu_linux.cson excluding es, ja, ko (translated) and zh-cn, zh-tw (under translation)
