### PR TITLE
Keep all cson data consistent

### DIFF
--- a/def/es/settings.cson
+++ b/def/es/settings.cson
@@ -64,6 +64,13 @@ Settings:
                individuales pueden tener sus propios ajustes en la
                <a class="link packages-open">lista de Paquetes</a>.'
       }
+      {
+        _id: 'editor-settings-note'
+        html: 'These settings are related to text editing. Some of these
+               can be overriden on a per-language basis. Check language
+               settings by clicking its package card in the
+               <a class="link packages-open">Packages list</a>.'
+      }
     ]
     controls: [
       {

--- a/def/ja/menu_linux.cson
+++ b/def/ja/menu_linux.cson
@@ -282,8 +282,6 @@ Menu:
         value: "ライセンス(&L)"
       "&Documentation":
         value: "ドキュメント(&D)"
-      Roadmap:
-        value: "ロードマップ"
       "Frequently Asked Questions":
         value: "よくあるご質問"
       "Community Discussions":

--- a/def/ja/menu_win32.cson
+++ b/def/ja/menu_win32.cson
@@ -282,8 +282,6 @@ Menu:
         value: "ライセンス"
       "&Documentation":
         value: "ドキュメント(&D)"
-      Roadmap:
-        value: "ロードマップ"
       "Frequently Asked Questions":
         value: "よくあるご質問"
       "Community Discussions":

--- a/def/ja/settings.cson
+++ b/def/ja/settings.cson
@@ -130,9 +130,22 @@ Settings:
         desc: "起動時に新規のエディタを自動的に開きます。"
       }
       {
+        _id: 'core.packagesWithKeymapsDisabled'
+        title: "Packages With Keymaps Disabled"
+      }
+      {
         _id: 'core.projectHome'
         title: "プロジェクトホーム"
         desc: "プロジェクト群を配置するディレクトリを指定します。パッケージジェネレータで作成されたパッケージはデフォルトでここが格納先となります。"
+      }
+      {
+        _id: 'core.reopenProjectMenuCount'
+        title: "Reopen Project Menu Count"
+        desc: "How many recent projects to show in the Reopen Project menu."
+      }
+      {
+        _id: 'core.restorePreviousWindowsOnStart'
+        title: "Restore Previous Windows On Start"
       }
       {
         _id: 'core.telemetryConsent'


### PR DESCRIPTION
- related issue #20

- TODOS
  - [x] update key-value pairs in all cson files to pass Travis CI
      - locally test: use `npm test`
  - [x] for each added key-value pair, create new issue of translation

- new values require translation
  - `es`: 1 #23
  - `ja`: 4  #22