### PR TITLE
Selecting 'Available Updates' element with new DOM structure for 1.16

### DIFF
--- a/def/ar/settings.cson
+++ b/def/ar/settings.cson
@@ -47,6 +47,7 @@ Settings:
     {_label: "Featured Packages", value: "Featured Packages"}
     {_label: "Install Themes", value: "Install Themes"}
     {_label: "Featured Themes", value: "Featured Themes"}
+    {_label: "Available Updates", value: "Available Updates"}
   ]
   "heading-available-updates": {_label: "Available Updates", value: "Available Updates"}
   subSectionHeadings: [

--- a/def/de/settings.cson
+++ b/def/de/settings.cson
@@ -47,6 +47,7 @@ Settings:
     {_label: "Featured Packages", value: "Präsentierte Pakete"}
     {_label: "Install Themes", value: "Themen installieren"}
     {_label: "Featured Themes", value: "Präsentierte Themen"}
+    {_label: "Available Updates", value: "Verfügbare Updates"}
   ]
   "heading-available-updates": {_label: "Available Updates", value: "Verfügbare Updates"}
   subSectionHeadings: [

--- a/def/es/settings.cson
+++ b/def/es/settings.cson
@@ -47,6 +47,7 @@ Settings:
     {_label: "Featured Packages", value: "Paquetes Destacados"}
     {_label: "Install Themes", value: "Instalar Temas"}
     {_label: "Featured Themes", value: "Temas Destacados"}
+    {_label: "Available Updates", value: "Actualizaciones Disponibles"}
   ]
   "heading-available-updates": {_label: "Available Updates", value: "Actualizaciones Disponibles"}
   subSectionHeadings: [

--- a/def/fr/settings.cson
+++ b/def/fr/settings.cson
@@ -47,6 +47,7 @@ Settings:
     {_label: "Featured Packages", value: "Featured Packages"}
     {_label: "Install Themes", value: "Install Themes"}
     {_label: "Featured Themes", value: "Featured Themes"}
+    {_label: "Available Updates", value: "Available Updates"}
   ]
   "heading-available-updates": {_label: "Available Updates", value: "Available Updates"}
   subSectionHeadings: [

--- a/def/hi/settings.cson
+++ b/def/hi/settings.cson
@@ -47,6 +47,7 @@ Settings:
     {_label: "Featured Packages", value: "Featured Packages"}
     {_label: "Install Themes", value: "Install Themes"}
     {_label: "Featured Themes", value: "Featured Themes"}
+    {_label: "Available Updates", value: "Available Updates"}
   ]
   "heading-available-updates": {_label: "Available Updates", value: "Available Updates"}
   subSectionHeadings: [

--- a/def/ja/settings.cson
+++ b/def/ja/settings.cson
@@ -47,6 +47,7 @@ Settings:
     {_label: "Featured Packages", value: "おすすめのパッケージ"}
     {_label: "Install Themes", value: "テーマのインストール"}
     {_label: "Featured Themes", value: "おすすめのテーマ"}
+    {_label: "Available Updates", value: "利用可能なアップデート"}
   ]
   "heading-available-updates": {_label: "Available Updates", value: "利用可能なアップデート"}
   subSectionHeadings: [

--- a/def/ko/settings.cson
+++ b/def/ko/settings.cson
@@ -47,6 +47,7 @@ Settings:
     {_label: "Featured Packages", value: "추천 패키지"}
     {_label: "Install Themes", value: "테마 설치"}
     {_label: "Featured Themes", value: "추천 테마"}
+    {_label: "Available Updates", value: "사용 가능한 업데이트"}
   ]
   "heading-available-updates": {_label: "Available Updates", value: "사용 가능한 업데이트"}
   subSectionHeadings: [

--- a/def/nl/settings.cson
+++ b/def/nl/settings.cson
@@ -47,6 +47,7 @@ Settings:
     {_label: "Featured Packages", value: "Featured Packages"}
     {_label: "Install Themes", value: "Install Themes"}
     {_label: "Featured Themes", value: "Featured Themes"}
+    {_label: "Available Updates", value: "Available Updates"}
   ]
   "heading-available-updates": {_label: "Available Updates", value: "Available Updates"}
   subSectionHeadings: [

--- a/def/pt-br/settings.cson
+++ b/def/pt-br/settings.cson
@@ -47,6 +47,7 @@ Settings:
     {_label: "Featured Packages", value: "Featured Packages"}
     {_label: "Install Themes", value: "Install Themes"}
     {_label: "Featured Themes", value: "Featured Themes"}
+    {_label: "Available Updates", value: "Available Updates"}
   ]
   "heading-available-updates": {_label: "Available Updates", value: "Available Updates"}
   subSectionHeadings: [

--- a/def/ru/settings.cson
+++ b/def/ru/settings.cson
@@ -47,6 +47,7 @@ Settings:
     {_label: "Featured Packages", value: "Лучшие расширения"}
     {_label: "Install Themes", value: "Установка тем"}
     {_label: "Featured Themes", value: "Лучшие темы"}
+    {_label: "Available Updates", value: "Доступные обновления"}
   ]
   "heading-available-updates": {_label: "Available Updates", value: "Доступные обновления"}
   subSectionHeadings: [

--- a/def/template/settings.cson
+++ b/def/template/settings.cson
@@ -47,6 +47,7 @@ Settings:
     {_label: "Featured Packages", value: "Featured Packages"}
     {_label: "Install Themes", value: "Install Themes"}
     {_label: "Featured Themes", value: "Featured Themes"}
+    {_label: "Available Updates", value: "Available Updates"}
   ]
   "heading-available-updates": {_label: "Available Updates", value: "Available Updates"}
   subSectionHeadings: [

--- a/def/zh-cn/settings.cson
+++ b/def/zh-cn/settings.cson
@@ -47,6 +47,7 @@ Settings:
     {_label: "Featured Packages", value: "热门插件包"}
     {_label: "Install Themes", value: "安装主题"}
     {_label: "Featured Themes", value: "热门主题"}
+    {_label: "Available Updates", value: "可用更新"}
   ]
   "heading-available-updates": {_label: "Available Updates", value: "可用更新"}
   subSectionHeadings: [

--- a/def/zh-tw/settings.cson
+++ b/def/zh-tw/settings.cson
@@ -47,6 +47,7 @@ Settings:
     {_label: "Featured Packages", value: "特色擴充套件"}
     {_label: "Install Themes", value: "安裝佈景主題"}
     {_label: "Featured Themes", value: "特色佈景主題"}
+    {_label: "Available Updates", value: "可用的更新"}
   ]
   "heading-available-updates": {_label: "Available Updates", value: "可用的更新"}
   subSectionHeadings: [

--- a/lib/preferences-util.coffee
+++ b/lib/preferences-util.coffee
@@ -8,6 +8,7 @@ class PreferencesUtil
     # org: original
     sh = @getTextMatchElement(area, '.section-heading', org)
     return unless sh && !@isAlreadyLocalized(sh)
+    return unless sh.childNodes[childIdx]
     sh.childNodes[childIdx].textContent = null
     span = document.createElement('span')
     span.textContent = org
@@ -16,6 +17,7 @@ class PreferencesUtil
 
   @applyTextWithOrg = (elem, text) ->
     return unless text
+    return unless elem
     before = String(elem.textContent)
     return if before == text
     elem.innerHTML = text    # NOTE text may contain HTML


### PR DESCRIPTION
fix #63 

- support 1.16 new DOM structure (currently beta)
- backward support for 1.15

NOTE: it's a temporarily fix for 1.15. Will be modified several versions after 1.15.