### PR TITLE
custom menu i18n

### DIFF
--- a/def/custom_menu.cson
+++ b/def/custom_menu.cson
@@ -1,0 +1,33 @@
+# This is where you can put custom definition
+# to translate menu item for community package.
+#
+# Following code are demos for two different situations
+
+
+Menu:  # Must keep this line
+
+# Case One: target is a *new* individual menu
+#
+#   "TITLE #1":
+#     value: "I18N TITLE #1"
+#     submenu:
+#       "ITEM #2":
+#         value: "I18N ITEM #2"
+#       "SUBTITLE #3":
+#         value: "I18N SUBTITLE #3"
+#         submenu:
+#           "SUBITEM #4":
+#             value: "I18N SUBITEM #4"
+
+
+# Case Two: target is in the *existed* translated menu
+#   for example let's translate "Minimap" into Japanese
+#
+#   "パッケージ(&P)":
+#     value: "パッケージ(&P)" # translated "Packages" into Japanese (see def/LOCALE/menu_*.cson for reference)
+#     submenu:
+#       "Minimap":
+#         value: "I18N: Minimap"
+#         submenu:
+#           "Toggle":
+#             value: "I18N: Toggle"

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,3 +1,4 @@
+fs = require 'fs'
 path = require 'path'
 CSON = require 'cson'
 Menu = require './menu'
@@ -14,6 +15,9 @@ class I18N
   constructor: ->
     LOCALE = atom.config.get('atom-i18n.locale')
     # BUG when running spec, LOCALE is not initialized
+    if not atom.config.get('atom-i18n.customMenuI18nPath')
+      atom.config.set('atom-i18n.customMenuI18nPath', path.join __dirname, "../def", "custom_menu.cson")
+
     @defM = CSON.load path.join __dirname, "../def", LOCALE, "menu_#{process.platform}.cson"
     @defC = CSON.load path.join __dirname, "../def", LOCALE, "context.cson"
     @defS = CSON.load path.join __dirname, "../def", LOCALE, "settings.cson"
@@ -22,6 +26,10 @@ class I18N
 
   activate: (state) ->
     setTimeout(@delay, 0)
+    setTimeout(@customMenuI18n, 3000)
+
+    atom.commands.add 'atom-workspace', 'atom-i18n:open-custom-menu-i18n-file', =>
+      atom.workspace.open atom.config.get('atom-i18n.customMenuI18nPath' )
 
   deactivate: () ->
     Util.promptUserReloadAtom("Reload Atom to clear translation.")
@@ -36,5 +44,10 @@ class I18N
 
     Util.handleConfigChange()
 
+  customMenuI18n: () =>
+    customMenuCson = atom.config.get('atom-i18n.customMenuI18nPath')
+    if fs.existsSync(customMenuCson)
+      @customDefM = CSON.load customMenuCson
+      Menu.localize(@customDefM)
 
 module.exports = window.I18N = new I18N()

--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -20,4 +20,7 @@ class Util
       newLangauge = @findLaguageNameByLocale(newLocale) || newLocale
       @promptUserReloadAtom("Reload Atom to translate into \n- `#{newLangauge}`.")
 
+    atom.config.onDidChange 'atom-i18n.customMenuI18nPath', () =>
+      @promptUserReloadAtom("Reload Atom to translate Custom Menus")
+
 module.exports = Util

--- a/package.json
+++ b/package.json
@@ -92,6 +92,12 @@
           "description": "English (en)"
         }
       ]
+    },
+    "customMenuI18nPath": {
+      "type": "string",
+      "default": "",
+      "title": "Custom Translation for Menu",
+      "description": "Translate community package (like <code>Minimap</code>) in menu bar by editing this file.</br> You can open it by command <code>atom-i18n:open-custom-menu-i18n-file</code>"
     }
   }
 }


### PR DESCRIPTION
adding custom i18n file to translate menu 
(this feature is mentioned in #56)

- add new template def/custom_menu.cson
- add config option in package.json
- wrap some code into util.coffee


You can use command `atom-i18n:open-custom-menu-i18n-file` to edit the file for custom menu i18n