### PR TITLE
Deprecate PR #76 and special heading in cson

### DIFF
--- a/def/ar/settings.cson
+++ b/def/ar/settings.cson
@@ -47,9 +47,8 @@ Settings:
     {_label: "Featured Packages", value: "Featured Packages"}
     {_label: "Install Themes", value: "Install Themes"}
     {_label: "Featured Themes", value: "Featured Themes"}
-    {_label: "Available Updates", value: "Available Updates", _childIndex: 2}
+    {_label: "Available Updates", value: "Available Updates"}
   ]
-  "heading-available-updates": {_label: "Available Updates", value: "Available Updates"}
   subSectionHeadings: [
     {_label: "Invisible", value: "Invisible"}
     {_label: "Community Packages", value: "Community Packages"}

--- a/def/de/settings.cson
+++ b/def/de/settings.cson
@@ -47,9 +47,8 @@ Settings:
     {_label: "Featured Packages", value: "Präsentierte Pakete"}
     {_label: "Install Themes", value: "Themen installieren"}
     {_label: "Featured Themes", value: "Präsentierte Themen"}
-    {_label: "Available Updates", value: "Verfügbare Updates", _childIndex: 2}
+    {_label: "Available Updates", value: "Verfügbare Updates"}
   ]
-  "heading-available-updates": {_label: "Available Updates", value: "Verfügbare Updates"}
   subSectionHeadings: [
     {_label: "Invisible", value: "Unsichtbar"}
     {_label: "Community Packages", value: "Community Pakete"}

--- a/def/es/settings.cson
+++ b/def/es/settings.cson
@@ -47,9 +47,8 @@ Settings:
     {_label: "Featured Packages", value: "Paquetes Destacados"}
     {_label: "Install Themes", value: "Instalar Temas"}
     {_label: "Featured Themes", value: "Temas Destacados"}
-    {_label: "Available Updates", value: "Actualizaciones Disponibles", _childIndex: 2}
+    {_label: "Available Updates", value: "Actualizaciones Disponibles"}
   ]
-  "heading-available-updates": {_label: "Available Updates", value: "Actualizaciones Disponibles"}
   subSectionHeadings: [
     {_label: "Invisible", value: "Invisible"}
     {_label: "Community Packages", value: "Paquetes de la Comunidad"}

--- a/def/fr/settings.cson
+++ b/def/fr/settings.cson
@@ -47,9 +47,8 @@ Settings:
     {_label: "Featured Packages", value: "Packages vedettes"}
     {_label: "Install Themes", value: "Installer des thèmes"}
     {_label: "Featured Themes", value: "Thèmes vedettes"}
-    {_label: "Available Updates", value: "Mises à jour disponnibles", _childIndex: 2}
+    {_label: "Available Updates", value: "Mises à jour disponnibles"}
   ]
-  "heading-available-updates": {_label: "Available Updates", value: "Mises à jour disponnibles"}
   subSectionHeadings: [
     {_label: "Invisible", value: "Invisible"}
     {_label: "Community Packages", value: "Packages tiers"}

--- a/def/hi/settings.cson
+++ b/def/hi/settings.cson
@@ -47,9 +47,8 @@ Settings:
     {_label: "Featured Packages", value: "Featured Packages"}
     {_label: "Install Themes", value: "Install Themes"}
     {_label: "Featured Themes", value: "Featured Themes"}
-    {_label: "Available Updates", value: "Available Updates", _childIndex: 2}
+    {_label: "Available Updates", value: "Available Updates"}
   ]
-  "heading-available-updates": {_label: "Available Updates", value: "Available Updates"}
   subSectionHeadings: [
     {_label: "Invisible", value: "Invisible"}
     {_label: "Community Packages", value: "Community Packages"}

--- a/def/ja/settings.cson
+++ b/def/ja/settings.cson
@@ -47,9 +47,8 @@ Settings:
     {_label: "Featured Packages", value: "おすすめのパッケージ"}
     {_label: "Install Themes", value: "テーマのインストール"}
     {_label: "Featured Themes", value: "おすすめのテーマ"}
-    {_label: "Available Updates", value: "利用可能なアップデート", _childIndex: 2}
+    {_label: "Available Updates", value: "利用可能なアップデート"}
   ]
-  "heading-available-updates": {_label: "Available Updates", value: "利用可能なアップデート"}
   subSectionHeadings: [
     {_label: "Invisible", value: "不可視文字"}
     {_label: "Community Packages", value: "コミュニティパッケージ"}

--- a/def/ko/settings.cson
+++ b/def/ko/settings.cson
@@ -47,9 +47,8 @@ Settings:
     {_label: "Featured Packages", value: "추천 패키지"}
     {_label: "Install Themes", value: "테마 설치"}
     {_label: "Featured Themes", value: "추천 테마"}
-    {_label: "Available Updates", value: "사용 가능한 업데이트", _childIndex: 2}
+    {_label: "Available Updates", value: "사용 가능한 업데이트"}
   ]
-  "heading-available-updates": {_label: "Available Updates", value: "사용 가능한 업데이트"}
   subSectionHeadings: [
     {_label: "Invisible", value: "비가시성 문자"}
     {_label: "Community Packages", value: "커뮤니티 패키지"}

--- a/def/nl/settings.cson
+++ b/def/nl/settings.cson
@@ -47,9 +47,8 @@ Settings:
     {_label: "Featured Packages", value: "Aanbevolen Pakketten"}
     {_label: "Install Themes", value: "Installeer Thema"}
     {_label: "Featured Themes", value: "Aanbevolen Thema's"}
-    {_label: "Available Updates", value: "Beschikbare Updates", _childIndex: 2}
+    {_label: "Available Updates", value: "Beschikbare Updates"}
   ]
-  "heading-available-updates": {_label: "Available Updates", value: "Beschikbare Updates"}
   subSectionHeadings: [
     {_label: "Invisible", value: "Onzichtbaar"}
     {_label: "Community Packages", value: "Community Pakketten"}

--- a/def/pt-br/settings.cson
+++ b/def/pt-br/settings.cson
@@ -47,9 +47,8 @@ Settings:
     {_label: "Featured Packages", value: "Featured Packages"}
     {_label: "Install Themes", value: "Install Themes"}
     {_label: "Featured Themes", value: "Featured Themes"}
-    {_label: "Available Updates", value: "Available Updates", _childIndex: 2}
+    {_label: "Available Updates", value: "Available Updates"}
   ]
-  "heading-available-updates": {_label: "Available Updates", value: "Available Updates"}
   subSectionHeadings: [
     {_label: "Invisible", value: "Invisible"}
     {_label: "Community Packages", value: "Community Packages"}

--- a/def/ru/settings.cson
+++ b/def/ru/settings.cson
@@ -47,9 +47,8 @@ Settings:
     {_label: "Featured Packages", value: "Лучшие расширения"}
     {_label: "Install Themes", value: "Установка тем"}
     {_label: "Featured Themes", value: "Лучшие темы"}
-    {_label: "Available Updates", value: "Доступные обновления", _childIndex: 2}
+    {_label: "Available Updates", value: "Доступные обновления"}
   ]
-  "heading-available-updates": {_label: "Available Updates", value: "Доступные обновления"}
   subSectionHeadings: [
     {_label: "Invisible", value: "Скрытие"}
     {_label: "Community Packages", value: "Пользовательские расширения"}

--- a/def/template/settings.cson
+++ b/def/template/settings.cson
@@ -47,9 +47,8 @@ Settings:
     {_label: "Featured Packages", value: "Featured Packages"}
     {_label: "Install Themes", value: "Install Themes"}
     {_label: "Featured Themes", value: "Featured Themes"}
-    {_label: "Available Updates", value: "Available Updates", _childIndex: 2}
+    {_label: "Available Updates", value: "Available Updates"}
   ]
-  "heading-available-updates": {_label: "Available Updates", value: "Available Updates"}
   subSectionHeadings: [
     {_label: "Invisible", value: "Invisible"}
     {_label: "Community Packages", value: "Community Packages"}

--- a/def/zh-cn/settings.cson
+++ b/def/zh-cn/settings.cson
@@ -47,9 +47,8 @@ Settings:
     {_label: "Featured Packages", value: "热门插件包"}
     {_label: "Install Themes", value: "安装主题"}
     {_label: "Featured Themes", value: "热门主题"}
-    {_label: "Available Updates", value: "可用更新", _childIndex: 2}
+    {_label: "Available Updates", value: "可用更新"}
   ]
-  "heading-available-updates": {_label: "Available Updates", value: "可用更新"}
   subSectionHeadings: [
     {_label: "Invisible", value: "隐藏字符"}
     {_label: "Community Packages", value: "社区插件包"}

--- a/def/zh-tw/settings.cson
+++ b/def/zh-tw/settings.cson
@@ -47,9 +47,8 @@ Settings:
     {_label: "Featured Packages", value: "特色擴充套件"}
     {_label: "Install Themes", value: "安裝佈景主題"}
     {_label: "Featured Themes", value: "特色佈景主題"}
-    {_label: "Available Updates", value: "可用的更新", _childIndex: 2}
+    {_label: "Available Updates", value: "可用的更新"}
   ]
-  "heading-available-updates": {_label: "Available Updates", value: "可用的更新"}
   subSectionHeadings: [
     {_label: "Invisible", value: "隱藏字元"}
     {_label: "Community Packages", value: "社群開發的擴充套件"}

--- a/lib/preferences-settings.coffee
+++ b/lib/preferences-settings.coffee
@@ -96,7 +96,6 @@ class PreferencesSettings
       info.setAttribute('data-localized', 'true')
 
   @localizeUpdatesPanel: () =>
-    PU.applySpecialHeading(@sv, @defS["heading-available-updates"]._label, 2, @defS["heading-available-updates"].value)
     PU.applyTextWithOrg(@sv.querySelector('.update-all-button.btn-primary'), @defS.updates["update-all"])
     PU.applyTextWithOrg(@sv.querySelector('.update-all-button:not(.btn-primary)'), @defS.updates["check-updates"])
     PU.applyTextWithOrg(@sv.querySelector('.alert.icon-hourglass'),  @defS.updates["checking-updates"])

--- a/lib/preferences-util.coffee
+++ b/lib/preferences-util.coffee
@@ -4,17 +4,6 @@ class PreferencesUtil
     localized = elem.getAttribute('data-localized') if elem
     return localized == 'true'
 
-  @applySpecialHeading = (area, org, childIdx, text) ->
-    # org: original
-    sh = @getTextMatchElement(area, '.section-heading', org)
-    return unless sh && !@isAlreadyLocalized(sh)
-    return unless sh.childNodes[childIdx]
-    sh.childNodes[childIdx].textContent = null
-    span = document.createElement('span')
-    span.textContent = org
-    @applyTextWithOrg(span, text)
-    sh.appendChild(span)
-
   @applyTextWithOrg = (elem, text, childIndex) ->
     childIndex = if (parseInt(atom.getVersion().split('.')[1]) > 15) then null else childIndex
     return unless text

--- a/lib/preferences-util.coffee
+++ b/lib/preferences-util.coffee
@@ -4,16 +4,12 @@ class PreferencesUtil
     localized = elem.getAttribute('data-localized') if elem
     return localized == 'true'
 
-  @applyTextWithOrg = (elem, text, childIndex) ->
-    childIndex = if (parseInt(atom.getVersion().split('.')[1]) > 15) then null else childIndex
+  @applyTextWithOrg = (elem, text) ->
     return unless text
     return unless elem
-    before = if not childIndex then String(elem.textContent) else String(elem.childNodes[childIndex].textContent)
+    before = String(elem.textContent)
     return if before == text
-    if not childIndex
-      elem.innerHTML = text    # NOTE text may contain HTML
-    else
-      elem.childNodes[childIndex].textContent = text
+    elem.innerHTML = text    # NOTE text may contain HTML
     elem.setAttribute('title', text)
     elem.setAttribute('data-localized', 'true')
     elem.setAttribute('data-before-localized', before)
@@ -33,7 +29,7 @@ class PreferencesUtil
       el = @getTextMatchElement(sv, '.section-heading', sh._label)
       continue unless el
       if !@isAlreadyLocalized(el) || force
-        @applyTextWithOrg(el, sh.value, sh._childIndex)
+        @applyTextWithOrg(el, sh.value)
     for sh in window.I18N.defS.Settings.subSectionHeadings
       el = @getTextMatchElement(sv, '.sub-section-heading', sh._label)
       continue unless el

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "repository": "https://github.com/liuderchi/atom-i18n",
   "license": "MIT",
   "engines": {
-    "atom": ">=1.15.0 <2.0.0"
+    "atom": ">=1.16.0 <2.0.0"
   },
   "dependencies": {
     "cson": "^4.0.0"


### PR DESCRIPTION
Since current versions are 1.18/1.17, deprecate work around for v1.15 in #75.

**Changes**
    
  - update atom version requirement to >= 1.16.0
  - remove all unused entries in `*.cson` with key 'heading-available-updates'
  - remove dependencies of 'heading-available-updates': `applySpecialHeading()`

**validation**
  - [x] I've validated my translation locally by running

`npm run validation -- --locale MY_LOCALE`
