### PR TITLE
Fix cson key inconsistent

### DIFF
--- a/def/ar/menu_darwin.cson
+++ b/def/ar/menu_darwin.cson
@@ -6,7 +6,7 @@ Menu:
         value: "About Atom"
       "View License":
         value: "View License"
-      "Check For Update":
+      "Check for Update":
         value: "Check for Update"
       "Preferences…":
         value: "Preferences..."

--- a/def/ar/menu_win32.cson
+++ b/def/ar/menu_win32.cson
@@ -289,7 +289,7 @@ Menu:
         value: "View &Terms of Use"
       "View &License":
         value: "View &License"
-      "Check For Update":
+      "Check for Update":
         value: "Check for Update"
       "&Documentation":
         value: "Documentation(&D)"

--- a/def/ar/settings.cson
+++ b/def/ar/settings.cson
@@ -158,6 +158,10 @@ Settings:
         _id: 'core.restorePreviousWindowsOnStart'
         title: "Restore Previous Windows On Start"
         desc: "When checked restores the last state of all Atom windows when started from the icon or <code>atom</code> by itself from the command line; otherwise a blank environment is loaded."
+        select:
+          no: "no"
+          yes: "yes"
+          always: "always"
       }
       {
         _id: 'core.telemetryConsent'

--- a/def/de/menu_darwin.cson
+++ b/def/de/menu_darwin.cson
@@ -6,7 +6,7 @@ Menu:
         value: "Über Atom"
       "View License":
         value: "Lizenzbedingungen anzeigen"
-      "Check For Update":
+      "Check for Update":
         value: "Check for Update"
       "Preferences…":
         value: "Einstellungen..."

--- a/def/de/menu_win32.cson
+++ b/def/de/menu_win32.cson
@@ -289,7 +289,7 @@ Menu:
         value: "Nu&tzungsbedingungen anzeigen"
       "View &License":
         value: "&Lizenzbedingungen anzeigen"
-      "Check For Update":
+      "Check for Update":
         value: "Check for Update"
       "&Documentation":
         value: "&Dokumentation"

--- a/def/de/settings.cson
+++ b/def/de/settings.cson
@@ -150,6 +150,10 @@ Settings:
         _id: 'core.restorePreviousWindowsOnStart'
         title: "Letzte Fenster beim Start wieder herstellen"
         desc: "When checked restores the last state of all Atom windows when started from the icon or <code>atom</code> by itself from the command line; otherwise a blank environment is loaded."
+        select:
+          no: "no"
+          yes: "yes"
+          always: "always"
       }
       {
         _id: 'core.telemetryConsent'

--- a/def/es/menu_darwin.cson
+++ b/def/es/menu_darwin.cson
@@ -6,7 +6,7 @@ Menu:
         value: "Acerca de Atom"
       "View License":
         value: "Ver Licencia"
-      "Check For Update":
+      "Check for Update":
         value: "Buscar Actualizaciones"
       "Preferences…":
         value: "Preferencias..."

--- a/def/es/menu_win32.cson
+++ b/def/es/menu_win32.cson
@@ -289,7 +289,7 @@ Menu:
         value: "Ver Términos de Uso(&T)"
       "View &License":
         value: "Ver Licencia(&L)"
-      "Check For Update":
+      "Check for Update":
         value: "Buscar Actualizaciones"
       "&Documentation":
         value: "Documentación(&D)"

--- a/def/es/settings.cson
+++ b/def/es/settings.cson
@@ -177,6 +177,10 @@ Settings:
         _id: 'core.restorePreviousWindowsOnStart'
         title: "Restaurar Ventana Previa al Iniciar"
         desc: "Cuando está marcada restaura el último estado de todas las ventanas de Atom cuando es iniciado desde el ícono o con <code>atom</code> desde la línea de comandos; caso contrario un ambiente en blanco es cargado."
+        select:
+          no: "no"
+          yes: "yes"
+          always: "always"
       }
       {
         _id: 'core.telemetryConsent'

--- a/def/fr/menu_darwin.cson
+++ b/def/fr/menu_darwin.cson
@@ -6,7 +6,7 @@ Menu:
         value: "À propos de Atom"
       "View License":
         value: "Voir la licence"
-      "Check For Update":
+      "Check for Update":
         value: "Vérifier les mises à jour"
       "Preferences…":
         value: "Préférences..."

--- a/def/hi/menu_darwin.cson
+++ b/def/hi/menu_darwin.cson
@@ -6,7 +6,7 @@ Menu:
         value: "About Atom"
       "View License":
         value: "View License"
-      "Check For Update":
+      "Check for Update":
         value: "Check for Update"
       "Preferences…":
         value: "Preferences..."

--- a/def/hi/menu_win32.cson
+++ b/def/hi/menu_win32.cson
@@ -289,7 +289,7 @@ Menu:
         value: "View &Terms of Use"
       "View &License":
         value: "View &License"
-      "Check For Update":
+      "Check for Update":
         value: "Check for Update"
       "&Documentation":
         value: "Documentation(&D)"

--- a/def/hi/settings.cson
+++ b/def/hi/settings.cson
@@ -158,6 +158,10 @@ Settings:
         _id: 'core.restorePreviousWindowsOnStart'
         title: "Restore Previous Windows On Start"
         desc: "When checked restores the last state of all Atom windows when started from the icon or <code>atom</code> by itself from the command line; otherwise a blank environment is loaded."
+        select:
+          no: "no"
+          yes: "yes"
+          always: "always"
       }
       {
         _id: 'core.telemetryConsent'

--- a/def/ja/menu_darwin.cson
+++ b/def/ja/menu_darwin.cson
@@ -6,7 +6,7 @@ Menu:
         value: "Atom について"
       "View License":
         value: "ライセンスを表示"
-      "Check For Update":
+      "Check for Update":
         value: "Check for Update"
       "Preferences…":
         value: "環境設定..."

--- a/def/ja/menu_win32.cson
+++ b/def/ja/menu_win32.cson
@@ -289,7 +289,7 @@ Menu:
         value: "利用条件(&T)"
       "View &License":
         value: "ライセンス(&L)"
-      "Check For Update":
+      "Check for Update":
         value: "Check for Update"
       "&Documentation":
         value: "ドキュメント(&D)"

--- a/def/ja/settings.cson
+++ b/def/ja/settings.cson
@@ -157,6 +157,10 @@ Settings:
         _id: 'core.restorePreviousWindowsOnStart'
         title: "Restore Previous Windows On Start"
         desc: "When checked restores the last state of all Atom windows when started from the icon or <code>atom</code> by itself from the command line; otherwise a blank environment is loaded."
+        select:
+          no: "no"
+          yes: "yes"
+          always: "always"
       }
       {
         _id: 'core.telemetryConsent'

--- a/def/ko/menu_darwin.cson
+++ b/def/ko/menu_darwin.cson
@@ -6,7 +6,7 @@ Menu:
         value: "Atom에 관하여"
       "View License":
         value: "라이센스 보기"
-      "Check For Update":
+      "Check for Update":
         value: "Check for Update"
       "Preferences…":
         value: "환경설정..."

--- a/def/ko/menu_win32.cson
+++ b/def/ko/menu_win32.cson
@@ -289,7 +289,7 @@ Menu:
         value: "이용약관 보기(&T)"
       "View &License":
         value: "라이센스 보기(&L)"
-      "Check For Update":
+      "Check for Update":
         value: "Check for Update"
       "&Documentation":
         value: "참조 문서(&D)"

--- a/def/ko/settings.cson
+++ b/def/ko/settings.cson
@@ -163,6 +163,10 @@ Settings:
         _id: 'core.restorePreviousWindowsOnStart'
         title: "시작 시 이전 창 복원"
         desc: "아이콘이나 커맨드 라인으로 <code>Atom</code>을 실행할 때 마지막 상태의 창으로 복원합니다. 그렇지 않으면 빈 환경으로 불러옵니다."
+        select:
+          no: "no"
+          yes: "yes"
+          always: "always"
       }
       {
         _id: 'core.telemetryConsent'

--- a/def/nl/menu_darwin.cson
+++ b/def/nl/menu_darwin.cson
@@ -6,7 +6,7 @@ Menu:
         value: "Over Atom"
       "View License":
         value: "Bekijk licentie"
-      "Check For Update":
+      "Check for Update":
         value: "Controleer op updates"
       "Preferences…":
         value: "Voorkeuren..."

--- a/def/nl/menu_win32.cson
+++ b/def/nl/menu_win32.cson
@@ -289,7 +289,7 @@ Menu:
         value: "View &Terms of Use"
       "View &License":
         value: "View &License"
-      "Check For Update":
+      "Check for Update":
         value: "Check for Update"
       "&Documentation":
         value: "Documentation(&D)"

--- a/def/nl/settings.cson
+++ b/def/nl/settings.cson
@@ -164,6 +164,10 @@ Settings:
         _id: 'core.restorePreviousWindowsOnStart'
         title: "Restore Previous Windows On Start"
         desc: "When checked restores the last state of all Atom windows when started from the icon or <code>atom</code> by itself from the command line; otherwise a blank environment is loaded."
+        select:
+          no: "no"
+          yes: "yes"
+          always: "always"
       }
       {
         _id: 'core.telemetryConsent'

--- a/def/pt-br/menu_darwin.cson
+++ b/def/pt-br/menu_darwin.cson
@@ -6,7 +6,7 @@ Menu:
         value: "Sobre Atom"
       "View License":
         value: "Ver Licença"
-      "Check For Update":
+      "Check for Update":
         value: "Verifique atualizações"
       "Preferences…":
         value: "Preferências..."

--- a/def/pt-br/menu_win32.cson
+++ b/def/pt-br/menu_win32.cson
@@ -289,7 +289,7 @@ Menu:
         value: "View &Terms of Use"
       "View &License":
         value: "Ver &Licença"
-      "Check For Update":
+      "Check for Update":
         value: "Verifique atualizações"
       "&Documentation":
         value: "Documentation(&D)"

--- a/def/pt-br/settings.cson
+++ b/def/pt-br/settings.cson
@@ -158,6 +158,10 @@ Settings:
         _id: 'core.restorePreviousWindowsOnStart'
         title: "Restore Previous Windows On Start"
         desc: "When checked restores the last state of all Atom windows when started from the icon or <code>atom</code> by itself from the command line; otherwise a blank environment is loaded."
+        select:
+          no: "no"
+          yes: "yes"
+          always: "always"
       }
       {
         _id: 'core.telemetryConsent'

--- a/def/ru/menu_darwin.cson
+++ b/def/ru/menu_darwin.cson
@@ -6,7 +6,7 @@ Menu:
         value: "О Atom"
       "View License":
         value: "Лицензия"
-      "Check For Update":
+      "Check for Update":
         value: "Проверить обновления"
       "Preferences…":
         value: "Настройки..."

--- a/def/ru/menu_win32.cson
+++ b/def/ru/menu_win32.cson
@@ -289,7 +289,7 @@ Menu:
         value: "Правила использования(&T)"
       "View &License":
         value: "Лицензия(&L)"
-      "Check For Update":
+      "Check for Update":
         value: "Проверить обновления"
       "&Documentation":
         value: "Документация(&D)"

--- a/def/ru/settings.cson
+++ b/def/ru/settings.cson
@@ -155,6 +155,10 @@ Settings:
         _id: 'core.restorePreviousWindowsOnStart'
         title: "Восстанавливать открытые окна при следующем запуске"
         desc: "Если стоит галочка то, восстанавливать все окна Atom из предыдущей сессии или отдельно из командной строки <code>atom</code>; иначе, будет загружен чистый лист."
+        select:
+          no: "no"
+          yes: "yes"
+          always: "always"
       }
       {
         _id: 'core.telemetryConsent'

--- a/def/template/menu_darwin.cson
+++ b/def/template/menu_darwin.cson
@@ -6,7 +6,7 @@ Menu:
         value: "About Atom"
       "View License":
         value: "View License"
-      "Check For Update":
+      "Check for Update":
         value: "Check for Update"
       "Preferences…":
         value: "Preferences..."

--- a/def/template/menu_win32.cson
+++ b/def/template/menu_win32.cson
@@ -289,7 +289,7 @@ Menu:
         value: "View &Terms of Use"
       "View &License":
         value: "View &License"
-      "Check For Update":
+      "Check for Update":
         value: "Check for Update"
       "&Documentation":
         value: "Documentation(&D)"

--- a/def/template/settings.cson
+++ b/def/template/settings.cson
@@ -158,6 +158,10 @@ Settings:
         _id: 'core.restorePreviousWindowsOnStart'
         title: "Restore Previous Windows On Start"
         desc: "When checked restores the last state of all Atom windows when started from the icon or <code>atom</code> by itself from the command line; otherwise a blank environment is loaded."
+        select:
+          no: "no"
+          yes: "yes"
+          always: "always"
       }
       {
         _id: 'core.telemetryConsent'

--- a/def/zh-cn/menu_darwin.cson
+++ b/def/zh-cn/menu_darwin.cson
@@ -6,7 +6,7 @@ Menu:
         value: "关于 Atom"
       "View License":
         value: "查看许可协议"
-      "Check For Update":
+      "Check for Update":
         value: "Check for Update"
       "Preferences…":
         value: "首选项..."

--- a/def/zh-cn/menu_win32.cson
+++ b/def/zh-cn/menu_win32.cson
@@ -289,7 +289,7 @@ Menu:
         value: "查看使用条款(&T)"
       "View &License":
         value: "查看许可协议(&L)"
-      "Check For Update":
+      "Check for Update":
         value: "Check for Update"
       "&Documentation":
         value: "官方文档(&D)"

--- a/def/zh-cn/settings.cson
+++ b/def/zh-cn/settings.cson
@@ -150,6 +150,10 @@ Settings:
         _id: 'core.restorePreviousWindowsOnStart'
         title: "启动时恢复之前的窗口状态"
         desc: "启用这个选项时，从桌面或是从命令行输入 <code>atom</code> 启动时，会恢复所有 Atom 窗口状态；否则，Atom 启动时会加载一个空白的工作环境。"
+        select:
+          no: "no"
+          yes: "yes"
+          always: "always"
       }
       {
         _id: 'core.telemetryConsent'

--- a/def/zh-tw/menu_darwin.cson
+++ b/def/zh-tw/menu_darwin.cson
@@ -6,7 +6,7 @@ Menu:
         value: "關於 Atom"
       "View License":
         value: "檢視授權"
-      "Check For Update":
+      "Check for Update":
         value: "檢查更新"
       "Preferences…":
         value: "偏好設定..."

--- a/def/zh-tw/menu_win32.cson
+++ b/def/zh-tw/menu_win32.cson
@@ -289,7 +289,7 @@ Menu:
         value: "檢視使用條款(&T)"
       "View &License":
         value: "檢視授權(&L)"
-      "Check For Update":
+      "Check for Update":
         value: "檢查更新"
       "&Documentation":
         value: "說明文件(&D)"

--- a/def/zh-tw/settings.cson
+++ b/def/zh-tw/settings.cson
@@ -150,6 +150,10 @@ Settings:
         _id: 'core.restorePreviousWindowsOnStart'
         title: "啟動時回復視窗狀態"
         desc: "當此選項勾選時，從桌面捷徑或是從命令列輸入 <code>atom</code> 啟動時會復原所有 Atom 視窗的狀態；否則，Atom 啟動時會開啟一個空白的工作環境。"
+        select:
+          no: "no"
+          yes: "yes"
+          always: "always"
       }
       {
         _id: 'core.telemetryConsent'


### PR DESCRIPTION
This PR is about fixing related changes in PR #88 and typo

- `restorePreviousWindowsOnStart` section in `settings.cson`
- typo: `Check For Update` in menu cson