### PR TITLE
Parse Settings from Atom Source Config Schema

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -17,6 +17,7 @@ globals:
   it: true
 extends: 'eslint:recommended'
 parserOptions:
+  ecmaVersion: 8
   sourceType: module
 rules:
   no-console: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-- '6'
+- '8'
 
 branches:
   only:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,7 +2,6 @@
   "name": "atom-i18n",
   "version": "0.12.0",
   "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
     "acorn": {
       "version": "5.1.1",
@@ -95,6 +94,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
       "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+      "dev": true
+    },
+    "axios": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.16.2.tgz",
+      "integrity": "sha1-uk+S8XFn37q0CYN4VFS5rBScPG0=",
       "dev": true
     },
     "babel-code-frame": {
@@ -697,6 +702,12 @@
         "write": "0.2.1"
       }
     },
+    "follow-redirects": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.2.4.tgz",
+      "integrity": "sha512-Suw6KewLV2hReSyEOeql+UUkBVyiBm3ok1VPrVFRZnQInWpdoZbbiG5i8aJVSjTr0yQ4Ava0Sh6/joCg1Brdqw==",
+      "dev": true
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -933,6 +944,12 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
       "dev": true
     },
     "is-builtin-module": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "cson": "^4.0.0"
   },
   "devDependencies": {
+    "axios": "^0.16.2",
     "chai": "^4.1.1",
     "coffeelint": "^1.16.0",
     "eslint": "^4.5.0",

--- a/spec/config.js
+++ b/spec/config.js
@@ -1,4 +1,4 @@
-const CsonFiles = [
+const CSON_FILES = [
   'menu_darwin.cson',
   'menu_linux.cson',
   'menu_win32.cson',
@@ -8,4 +8,9 @@ const CsonFiles = [
   'welcome.cson',
 ]
 
-module.exports = CsonFiles
+const ATOM_VERSION = 'v1.19.0'
+
+module.exports = {
+  CSON_FILES,
+  ATOM_VERSION,
+}

--- a/spec/validation.js
+++ b/spec/validation.js
@@ -17,6 +17,8 @@ const { flattenObj } = require('./util.js')
 const LOCALES = require('./locales.js')
 const CsonFiles = require('./defs.js')
 
+const ATOMVERSION = 'v1.19.0'
+
 describe('validation', () => {
 
   describe('package.json validation', () => {
@@ -36,6 +38,45 @@ describe('validation', () => {
   })
 
   describe('cson file validation', () => {
+
+    describe('checking template/settings.cson `controls.*._id` according atom config-schema.js', () => {
+
+      it('compares keys with flatten config-schema.js', done => {
+        const neverShownDesciptionInSettingsPanelItems = [
+          'core.customFileTypes',
+          'core.disabledPackages',
+          'core.themes',
+          'editor.commentEnd',
+          'editor.commentStart',
+          'editor.decreaseIndentPattern',
+          'editor.foldEndPattern',
+          'editor.increaseIndentPattern',
+          'editor.invisibles',   // NOTE shows only editor.invisibles.*
+        ]    // NOTE Manually updated exceptional list from https://github.com/atom/settings-view/blob/master/lib/settings-panel.js#L339-L350
+
+        const templateSettingsControls = CSON.load(path.join(__dirname, '../def/template', 'settings.cson'))
+          .Settings.settings.controls.map(({ _id }) => _id)
+
+        const axios = require('axios')
+        const configURL = `https://raw.githubusercontent.com/atom/atom/${ATOMVERSION}/src/config-schema.js`
+        axios.get(configURL).then(({ data }) => {
+          try {
+            const srcConfig = eval(data)
+            const flattenSrcConfigKeys = Object.keys(flattenObj(srcConfig))
+              .filter(key => key.search(/enum/g) === -1)
+              .filter(key => key.search(/description$/g) > -1)
+              .map(key => key.replace(/\.properties/g, '').replace(/\.description/g, ''))
+
+            expect(templateSettingsControls.concat(neverShownDesciptionInSettingsPanelItems))
+              .to.include.members(flattenSrcConfigKeys, 'inconsistent keys')
+            // NOTE expect all interested keys in `flattenSrcConfigKeys` appears in templateSettingsControls
+            done()
+          } catch (err) {
+            done(err)  // handle assertion fails error, to avoid test timeout
+          }
+        }, done)    // should always run done() when promise-resolved, assertion-fail-error, promise-rejected
+      })
+    })
 
     describe('checking each cson files of all locales', () => {
       const templateKeys = {}

--- a/spec/validation.js
+++ b/spec/validation.js
@@ -41,7 +41,7 @@ describe('validation', () => {
 
     describe('checking template/settings.cson `controls.*._id` according atom config-schema.js', () => {
 
-      it('compares keys with flatten config-schema.js', done => {
+      it('fetches config-schema.js then compares keys of settings.cson with it', () => {
         const neverShownDesciptionInSettingsPanelItems = [
           'core.customFileTypes',
           'core.disabledPackages',
@@ -59,22 +59,18 @@ describe('validation', () => {
 
         const axios = require('axios')
         const configURL = `https://raw.githubusercontent.com/atom/atom/${ATOMVERSION}/src/config-schema.js`
-        axios.get(configURL).then(({ data }) => {
-          try {
-            const srcConfig = eval(data)
-            const flattenSrcConfigKeys = Object.keys(flattenObj(srcConfig))
-              .filter(key => key.search(/enum/g) === -1)
-              .filter(key => key.search(/description$/g) > -1)
-              .map(key => key.replace(/\.properties/g, '').replace(/\.description/g, ''))
+        console.info(`fetching ${configURL}...`)
+        return axios.get(configURL).then(({ data }) => {
+          const srcConfig = eval(data)
+          const flattenSrcConfigKeys = Object.keys(flattenObj(srcConfig))
+            .filter(key => key.search(/enum/g) === -1)
+            .filter(key => key.search(/description$/g) > -1)
+            .map(key => key.replace(/\.properties/g, '').replace(/\.description/g, ''))
 
-            expect(templateSettingsControls.concat(neverShownDesciptionInSettingsPanelItems))
-              .to.include.members(flattenSrcConfigKeys, 'inconsistent keys')
-            // NOTE expect all interested keys in `flattenSrcConfigKeys` appears in templateSettingsControls
-            done()
-          } catch (err) {
-            done(err)  // handle assertion fails error, to avoid test timeout
-          }
-        }, done)    // should always run done() when promise-resolved, assertion-fail-error, promise-rejected
+          expect(templateSettingsControls.concat(neverShownDesciptionInSettingsPanelItems))
+            .to.include.members(flattenSrcConfigKeys, `inconsistent keys compared with ${configURL}\n`)
+          // NOTE expect every key `flattenSrcConfigKeys` appears in templateSettingsControls
+        })
       })
     })
 

--- a/spec/validation.js
+++ b/spec/validation.js
@@ -41,7 +41,7 @@ describe('validation', () => {
 
     describe('checking template/settings.cson `controls.*._id` according atom config-schema.js', () => {
 
-      it('fetches config-schema.js then compares keys of settings.cson with it', () => {
+      it('fetches config-schema.js then compares keys of settings.cson with it', async () => {
         const neverShownDesciptionInSettingsPanelItems = [
           'core.customFileTypes',
           'core.disabledPackages',
@@ -60,17 +60,18 @@ describe('validation', () => {
         const axios = require('axios')
         const configURL = `https://raw.githubusercontent.com/atom/atom/${ATOMVERSION}/src/config-schema.js`
         console.info(`fetching ${configURL}...`)
-        return axios.get(configURL).then(({ data }) => {
+
+        const flattenSrcConfigKeys = await axios.get(configURL).then(({ data }) => {
           const srcConfig = eval(data)
-          const flattenSrcConfigKeys = Object.keys(flattenObj(srcConfig))
+          return Object.keys(flattenObj(srcConfig))
             .filter(key => key.search(/enum/g) === -1)
             .filter(key => key.search(/description$/g) > -1)
             .map(key => key.replace(/\.properties/g, '').replace(/\.description/g, ''))
-
-          expect(templateSettingsControls.concat(neverShownDesciptionInSettingsPanelItems))
-            .to.include.members(flattenSrcConfigKeys, `inconsistent keys compared with ${configURL}\n`)
-          // NOTE expect every key `flattenSrcConfigKeys` appears in templateSettingsControls
         })
+
+        expect(templateSettingsControls.concat(neverShownDesciptionInSettingsPanelItems))
+          .to.include.members(flattenSrcConfigKeys, `inconsistent keys compared with ${configURL}\n`)
+        // NOTE expect every key `flattenSrcConfigKeys` appears in templateSettingsControls
       })
     })
 

--- a/spec/validation.js
+++ b/spec/validation.js
@@ -15,9 +15,7 @@ const { expect } = require('chai')
 
 const { flattenObj } = require('./util.js')
 const LOCALES = require('./locales.js')
-const CsonFiles = require('./defs.js')
-
-const ATOMVERSION = 'v1.19.0'
+const { CSON_FILES, ATOM_VERSION } = require('./config.js')
 
 describe('validation', () => {
 
@@ -58,7 +56,7 @@ describe('validation', () => {
           .Settings.settings.controls.map(({ _id }) => _id)
 
         const axios = require('axios')
-        const configURL = `https://raw.githubusercontent.com/atom/atom/${ATOMVERSION}/src/config-schema.js`
+        const configURL = `https://raw.githubusercontent.com/atom/atom/${ATOM_VERSION}/src/config-schema.js`
         console.info(`fetching ${configURL}...`)
 
         const flattenSrcConfigKeys = await axios.get(configURL).then(({ data }) => {
@@ -77,7 +75,7 @@ describe('validation', () => {
 
     describe('checking each cson files of all locales', () => {
       const templateKeys = {}
-      CsonFiles.forEach(csonFile => {
+      CSON_FILES.forEach(csonFile => {
         templateKeys[csonFile] = Object.keys(flattenObj(CSON.load(path.join(__dirname, '../def/template', csonFile))))
       })
 
@@ -86,7 +84,7 @@ describe('validation', () => {
 
         describe(`checking locale ${locale}`, () => {
 
-          CsonFiles.forEach(csonFile => {
+          CSON_FILES.forEach(csonFile => {
 
             describe(`checking "${path.join(locale, csonFile)}"`, () => {
 


### PR DESCRIPTION
### Abstract

Adding fetching atom source [`config-schema.js`](https://raw.githubusercontent.com/atom/atom/master/src/config-schema.js) logic 
to check correctness of [*controls section* in `template/settings.cson`](https://github.com/liuderchi/atom-i18n/blob/parse-settings-from-atom-src/def/template/settings.cson#L80) in validation

### Changes

- use `async` `await` to handle ajax in validation, update node version in CI
- manually keep an js list of exception fields of config to pass validation