### PR TITLE
Bump Atom version for Validation

### DIFF
--- a/def/ar/settings.cson
+++ b/def/ar/settings.cson
@@ -126,6 +126,14 @@ Settings:
         desc: "Default character set encoding to use when reading and writing files."
       }
       {
+        _id: 'core.fileSystemWatcher'
+        title: "File System Watcher"
+        desc: "Choose the underlying implementation used to watch for filesystem changes. Emulating changes will miss any events caused by applications other than Atom, but may help prevent crashes or freezes."
+        select:
+          native: "Native operating system APIs"
+          atom: "Emulated with Atom events"
+      }
+      {
         _id: 'core.followSymlinks'
         title: "Follow Symlinks"
         desc: "Follow symbolic links when searching files and when opening files with the fuzzy finder."

--- a/def/ar/settings.cson
+++ b/def/ar/settings.cson
@@ -276,6 +276,11 @@ Settings:
         desc: "Height of editor lines, as a multiplier of font size."
       }
       {
+        _id: 'editor.maxScreenLineLength'
+        title: "Max Screen Line Length"
+        desc: "Defines the maximum width of the editor window before soft wrapping is enforced, in number of characters."
+      }
+      {
         _id: 'editor.nonWordCharacters'
         title: "Non Word Characters"
         desc: "A string of non-word characters to define word boundaries."

--- a/def/de/settings.cson
+++ b/def/de/settings.cson
@@ -118,6 +118,14 @@ Settings:
         desc: "Vorgabe der Zeichencodierung, welche zum Lesen und Schreiben von Dateien verwendet wird."
       }
       {
+        _id: 'core.fileSystemWatcher'
+        title: "File System Watcher"
+        desc: "Choose the underlying implementation used to watch for filesystem changes. Emulating changes will miss any events caused by applications other than Atom, but may help prevent crashes or freezes."
+        select:
+          native: "Native operating system APIs"
+          atom: "Emulated with Atom events"
+      }
+      {
         _id: 'core.followSymlinks'
         title: "Symlinks folgen"
         desc: "Atom folgt beim Suchen von Dateien, und beim Öffnen von Ordnern mit dem fuzzy Finder, symbolischen Verknüpfungen."

--- a/def/de/settings.cson
+++ b/def/de/settings.cson
@@ -263,6 +263,11 @@ Settings:
         desc: "Höhe der Textzeilen, als Multiplikator der Schrifttypgröße."
       }
       {
+        _id: 'editor.maxScreenLineLength'
+        title: "Max Screen Line Length"
+        desc: "Defines the maximum width of the editor window before soft wrapping is enforced, in number of characters."
+      }
+      {
         _id: 'editor.nonWordCharacters'
         title: "Nicht-Buchstaben-Zeichen"
         desc: "Ein Zeichensatz von Nicht-Buchstaben-Zeichen um Wortgrenzen darzustellen."

--- a/def/es/settings.cson
+++ b/def/es/settings.cson
@@ -138,6 +138,14 @@ Settings:
                escribe archivos."
       }
       {
+        _id: 'core.fileSystemWatcher'
+        title: "File System Watcher"
+        desc: "Choose the underlying implementation used to watch for filesystem changes. Emulating changes will miss any events caused by applications other than Atom, but may help prevent crashes or freezes."
+        select:
+          native: "Native operating system APIs"
+          atom: "Emulated with Atom events"
+      }
+      {
         _id: 'core.followSymlinks'
         title: "Seguir Enlaces Simbólicos"
         desc: "Seguir enlaces simbólicos cuando se busca archivos y cuando se

--- a/def/es/settings.cson
+++ b/def/es/settings.cson
@@ -306,6 +306,11 @@ Settings:
                de la fuente."
       }
       {
+        _id: 'editor.maxScreenLineLength'
+        title: "Max Screen Line Length"
+        desc: "Defines the maximum width of the editor window before soft wrapping is enforced, in number of characters."
+      }
+      {
         _id: 'editor.nonWordCharacters'
         title: "Caracteres Que No Son Palabras"
         desc: "Una cadena de caracteres que no son palabras para definir

--- a/def/fr/settings.cson
+++ b/def/fr/settings.cson
@@ -278,6 +278,11 @@ Settings:
         desc: "Hauteur des lignes de l'éditeur sous forme du coefficient multiplicateur de la taille de la police."
       }
       {
+        _id: 'editor.maxScreenLineLength'
+        title: "Max Screen Line Length"
+        desc: "Defines the maximum width of the editor window before soft wrapping is enforced, in number of characters."
+      }
+      {
         _id: 'editor.nonWordCharacters'
         title: "Caractères non-alphanumériques"
         desc: "Une chaîne des caractères n'apparaissant pas dans les mots pour pouvoir les délimiter."

--- a/def/fr/settings.cson
+++ b/def/fr/settings.cson
@@ -127,6 +127,14 @@ Settings:
         desc: "Encodage de caractères par défaut lors de la lecture et l'écriture des fichiers."
       }
       {
+        _id: 'core.fileSystemWatcher'
+        title: "File System Watcher"
+        desc: "Choose the underlying implementation used to watch for filesystem changes. Emulating changes will miss any events caused by applications other than Atom, but may help prevent crashes or freezes."
+        select:
+          native: "Native operating system APIs"
+          atom: "Emulated with Atom events"
+      }
+      {
         _id: 'core.followSymlinks'
         title: "Suivre les liens symboliques"
         desc: "Suivre les liens symboliques lors de la recherche de fichiers et lors de l'ouverture de fichiers avec fuzzy-finder."

--- a/def/hi/settings.cson
+++ b/def/hi/settings.cson
@@ -126,6 +126,14 @@ Settings:
         desc: "Default character set encoding to use when reading and writing files."
       }
       {
+        _id: 'core.fileSystemWatcher'
+        title: "File System Watcher"
+        desc: "Choose the underlying implementation used to watch for filesystem changes. Emulating changes will miss any events caused by applications other than Atom, but may help prevent crashes or freezes."
+        select:
+          native: "Native operating system APIs"
+          atom: "Emulated with Atom events"
+      }
+      {
         _id: 'core.followSymlinks'
         title: "Follow Symlinks"
         desc: "Follow symbolic links when searching files and when opening files with the fuzzy finder."

--- a/def/hi/settings.cson
+++ b/def/hi/settings.cson
@@ -276,6 +276,11 @@ Settings:
         desc: "Height of editor lines, as a multiplier of font size."
       }
       {
+        _id: 'editor.maxScreenLineLength'
+        title: "Max Screen Line Length"
+        desc: "Defines the maximum width of the editor window before soft wrapping is enforced, in number of characters."
+      }
+      {
         _id: 'editor.nonWordCharacters'
         title: "Non Word Characters"
         desc: "A string of non-word characters to define word boundaries."

--- a/def/it/settings.cson
+++ b/def/it/settings.cson
@@ -126,6 +126,14 @@ Settings:
         desc: "Default character set encoding to use when reading and writing files."
       }
       {
+        _id: 'core.fileSystemWatcher'
+        title: "File System Watcher"
+        desc: "Choose the underlying implementation used to watch for filesystem changes. Emulating changes will miss any events caused by applications other than Atom, but may help prevent crashes or freezes."
+        select:
+          native: "Native operating system APIs"
+          atom: "Emulated with Atom events"
+      }
+      {
         _id: 'core.followSymlinks'
         title: "Follow Symlinks"
         desc: "Follow symbolic links when searching files and when opening files with the fuzzy finder."

--- a/def/it/settings.cson
+++ b/def/it/settings.cson
@@ -276,6 +276,11 @@ Settings:
         desc: "Height of editor lines, as a multiplier of font size."
       }
       {
+        _id: 'editor.maxScreenLineLength'
+        title: "Max Screen Line Length"
+        desc: "Defines the maximum width of the editor window before soft wrapping is enforced, in number of characters."
+      }
+      {
         _id: 'editor.nonWordCharacters'
         title: "Non Word Characters"
         desc: "A string of non-word characters to define word boundaries."

--- a/def/ja/settings.cson
+++ b/def/ja/settings.cson
@@ -124,6 +124,14 @@ Settings:
         desc: "ファイルを読み書きするためのデフォルトキャラクタセットを指定します。"
       }
       {
+        _id: 'core.fileSystemWatcher'
+        title: "File System Watcher"
+        desc: "Choose the underlying implementation used to watch for filesystem changes. Emulating changes will miss any events caused by applications other than Atom, but may help prevent crashes or freezes."
+        select:
+          native: "Native operating system APIs"
+          atom: "Emulated with Atom events"
+      }
+      {
         _id: 'core.followSymlinks'
         title: "シンボリックリンクをたどる"
         desc: "あいまい検索でファイルを検索・開く時に使用されます。"

--- a/def/ja/settings.cson
+++ b/def/ja/settings.cson
@@ -270,6 +270,11 @@ Settings:
         desc: "line-height (number)"
       }
       {
+        _id: 'editor.maxScreenLineLength'
+        title: "Max Screen Line Length"
+        desc: "Defines the maximum width of the editor window before soft wrapping is enforced, in number of characters."
+      }
+      {
         _id: 'editor.nonWordCharacters'
         title: "単語の一部として扱わない文字"
         desc: "単語の境界を定めるための文字"

--- a/def/ko/settings.cson
+++ b/def/ko/settings.cson
@@ -276,6 +276,11 @@ Settings:
         desc: "에디터 행의 높이이며 폰트 크기에 추가로 늘어납니다."
       }
       {
+        _id: 'editor.maxScreenLineLength'
+        title: "Max Screen Line Length"
+        desc: "Defines the maximum width of the editor window before soft wrapping is enforced, in number of characters."
+      }
+      {
         _id: 'editor.nonWordCharacters'
         title: "비단어 문자"
         desc: "단어의 경계를 구분할 비단어 문자의 나열입니다."

--- a/def/ko/settings.cson
+++ b/def/ko/settings.cson
@@ -129,6 +129,14 @@ Settings:
         desc: "파일을 읽거나 작성할 때 사용할 기본 문자 세트를 지정합니다."
       }
       {
+        _id: 'core.fileSystemWatcher'
+        title: "File System Watcher"
+        desc: "Choose the underlying implementation used to watch for filesystem changes. Emulating changes will miss any events caused by applications other than Atom, but may help prevent crashes or freezes."
+        select:
+          native: "Native operating system APIs"
+          atom: "Emulated with Atom events"
+      }
+      {
         _id: 'core.followSymlinks'
         title: "심링크 따라가기"
         desc: "파일을 찾거나 fuzzy finder로 열 때 심링크를 따라갑니다."

--- a/def/nl/settings.cson
+++ b/def/nl/settings.cson
@@ -132,6 +132,14 @@ Settings:
         desc: "Default character set encoding to use when reading and writing files."
       }
       {
+        _id: 'core.fileSystemWatcher'
+        title: "File System Watcher"
+        desc: "Choose the underlying implementation used to watch for filesystem changes. Emulating changes will miss any events caused by applications other than Atom, but may help prevent crashes or freezes."
+        select:
+          native: "Native operating system APIs"
+          atom: "Emulated with Atom events"
+      }
+      {
         _id: 'core.followSymlinks'
         title: "Follow Symlinks"
         desc: "Follow symbolic links when searching files and when opening files with the fuzzy finder."

--- a/def/nl/settings.cson
+++ b/def/nl/settings.cson
@@ -282,6 +282,11 @@ Settings:
         desc: "Height of editor lines, as a multiplier of font size."
       }
       {
+        _id: 'editor.maxScreenLineLength'
+        title: "Max Screen Line Length"
+        desc: "Defines the maximum width of the editor window before soft wrapping is enforced, in number of characters."
+      }
+      {
         _id: 'editor.nonWordCharacters'
         title: "Non Word Characters"
         desc: "A string of non-word characters to define word boundaries."

--- a/def/pl/settings.cson
+++ b/def/pl/settings.cson
@@ -126,6 +126,14 @@ Settings:
         desc: "Default character set encoding to use when reading and writing files."
       }
       {
+        _id: 'core.fileSystemWatcher'
+        title: "File System Watcher"
+        desc: "Choose the underlying implementation used to watch for filesystem changes. Emulating changes will miss any events caused by applications other than Atom, but may help prevent crashes or freezes."
+        select:
+          native: "Native operating system APIs"
+          atom: "Emulated with Atom events"
+      }
+      {
         _id: 'core.followSymlinks'
         title: "Follow Symlinks"
         desc: "Follow symbolic links when searching files and when opening files with the fuzzy finder."

--- a/def/pl/settings.cson
+++ b/def/pl/settings.cson
@@ -276,6 +276,11 @@ Settings:
         desc: "Height of editor lines, as a multiplier of font size."
       }
       {
+        _id: 'editor.maxScreenLineLength'
+        title: "Max Screen Line Length"
+        desc: "Defines the maximum width of the editor window before soft wrapping is enforced, in number of characters."
+      }
+      {
         _id: 'editor.nonWordCharacters'
         title: "Non Word Characters"
         desc: "A string of non-word characters to define word boundaries."

--- a/def/pt-br/settings.cson
+++ b/def/pt-br/settings.cson
@@ -126,6 +126,14 @@ Settings:
         desc: "Default character set encoding to use when reading and writing files."
       }
       {
+        _id: 'core.fileSystemWatcher'
+        title: "File System Watcher"
+        desc: "Choose the underlying implementation used to watch for filesystem changes. Emulating changes will miss any events caused by applications other than Atom, but may help prevent crashes or freezes."
+        select:
+          native: "Native operating system APIs"
+          atom: "Emulated with Atom events"
+      }
+      {
         _id: 'core.followSymlinks'
         title: "Follow Symlinks"
         desc: "Follow symbolic links when searching files and when opening files with the fuzzy finder."

--- a/def/pt-br/settings.cson
+++ b/def/pt-br/settings.cson
@@ -276,6 +276,11 @@ Settings:
         desc: "Height of editor lines, as a multiplier of font size."
       }
       {
+        _id: 'editor.maxScreenLineLength'
+        title: "Max Screen Line Length"
+        desc: "Defines the maximum width of the editor window before soft wrapping is enforced, in number of characters."
+      }
+      {
         _id: 'editor.nonWordCharacters'
         title: "Non Word Characters"
         desc: "A string of non-word characters to define word boundaries."

--- a/def/ru/settings.cson
+++ b/def/ru/settings.cson
@@ -123,6 +123,14 @@ Settings:
         desc: "Кодировка файла используемая по-умолчанию для записи и чтения файлов."
       }
       {
+        _id: 'core.fileSystemWatcher'
+        title: "File System Watcher"
+        desc: "Choose the underlying implementation used to watch for filesystem changes. Emulating changes will miss any events caused by applications other than Atom, but may help prevent crashes or freezes."
+        select:
+          native: "Native operating system APIs"
+          atom: "Emulated with Atom events"
+      }
+      {
         _id: 'core.followSymlinks'
         title: "Соблюдать символику"
         desc: "Соблюдать символику при поиске или открытии файло в древе."

--- a/def/ru/settings.cson
+++ b/def/ru/settings.cson
@@ -272,6 +272,11 @@ Settings:
         desc: "Высота строк редактора по отношению к размеру шрифта."
       }
       {
+        _id: 'editor.maxScreenLineLength'
+        title: "Max Screen Line Length"
+        desc: "Defines the maximum width of the editor window before soft wrapping is enforced, in number of characters."
+      }
+      {
         _id: 'editor.nonWordCharacters'
         title: "Не буквы"
         desc: "Строка символов для определения границы слов."

--- a/def/template/settings.cson
+++ b/def/template/settings.cson
@@ -126,6 +126,14 @@ Settings:
         desc: "Default character set encoding to use when reading and writing files."
       }
       {
+        _id: 'core.fileSystemWatcher'
+        title: "File System Watcher"
+        desc: "Choose the underlying implementation used to watch for filesystem changes. Emulating changes will miss any events caused by applications other than Atom, but may help prevent crashes or freezes."
+        select:
+          native: "Native operating system APIs"
+          atom: "Emulated with Atom events"
+      }
+      {
         _id: 'core.followSymlinks'
         title: "Follow Symlinks"
         desc: "Follow symbolic links when searching files and when opening files with the fuzzy finder."

--- a/def/template/settings.cson
+++ b/def/template/settings.cson
@@ -276,6 +276,11 @@ Settings:
         desc: "Height of editor lines, as a multiplier of font size."
       }
       {
+        _id: 'editor.maxScreenLineLength'
+        title: "Max Screen Line Length"
+        desc: "Defines the maximum width of the editor window before soft wrapping is enforced, in number of characters."
+      }
+      {
         _id: 'editor.nonWordCharacters'
         title: "Non Word Characters"
         desc: "A string of non-word characters to define word boundaries."

--- a/def/th/settings.cson
+++ b/def/th/settings.cson
@@ -126,6 +126,14 @@ Settings:
         desc: "Default character set encoding to use when reading and writing files."
       }
       {
+        _id: 'core.fileSystemWatcher'
+        title: "File System Watcher"
+        desc: "Choose the underlying implementation used to watch for filesystem changes. Emulating changes will miss any events caused by applications other than Atom, but may help prevent crashes or freezes."
+        select:
+          native: "Native operating system APIs"
+          atom: "Emulated with Atom events"
+      }
+      {
         _id: 'core.followSymlinks'
         title: "Follow Symlinks"
         desc: "Follow symbolic links when searching files and when opening files with the fuzzy finder."

--- a/def/th/settings.cson
+++ b/def/th/settings.cson
@@ -276,6 +276,11 @@ Settings:
         desc: "Height of editor lines, as a multiplier of font size."
       }
       {
+        _id: 'editor.maxScreenLineLength'
+        title: "Max Screen Line Length"
+        desc: "Defines the maximum width of the editor window before soft wrapping is enforced, in number of characters."
+      }
+      {
         _id: 'editor.nonWordCharacters'
         title: "Non Word Characters"
         desc: "A string of non-word characters to define word boundaries."

--- a/def/zh-cn/settings.cson
+++ b/def/zh-cn/settings.cson
@@ -118,6 +118,14 @@ Settings:
         desc: "读写文件时默认使用的字符编码。"
       }
       {
+        _id: 'core.fileSystemWatcher'
+        title: "File System Watcher"
+        desc: "Choose the underlying implementation used to watch for filesystem changes. Emulating changes will miss any events caused by applications other than Atom, but may help prevent crashes or freezes."
+        select:
+          native: "Native operating system APIs"
+          atom: "Emulated with Atom events"
+      }
+      {
         _id: 'core.followSymlinks'
         title: "使用软链接（Symbolic link）"
         desc: "当查找或者在模糊查找中打开文件时遵循软链接（symbolic links）导向。"

--- a/def/zh-cn/settings.cson
+++ b/def/zh-cn/settings.cson
@@ -263,6 +263,11 @@ Settings:
         desc: "编辑器内文字的行高，是字体大小的倍数。"
       }
       {
+        _id: 'editor.maxScreenLineLength'
+        title: "Max Screen Line Length"
+        desc: "Defines the maximum width of the editor window before soft wrapping is enforced, in number of characters."
+      }
+      {
         _id: 'editor.nonWordCharacters'
         title: "不作为单词的字符"
         desc: "下列字符将不被视为单词，而是作为单词边界。"

--- a/def/zh-tw/settings.cson
+++ b/def/zh-tw/settings.cson
@@ -118,6 +118,14 @@ Settings:
         desc: "設定讀寫檔案時預設使用的字元集編碼。"
       }
       {
+        _id: 'core.fileSystemWatcher'
+        title: "檔案系統監控"
+        desc: "選擇監控檔案系統變化所使用的底層實作。選擇模擬的實作會導致 Atom 錯過 Atom 之外其他應用程式產生的事件，但是可以避免 Atom 當機或畫面停滯。"
+        select:
+          native: "原生作業系統應用程式介面"
+          atom: "以 Atom 事件模擬"
+      }
+      {
         _id: 'core.followSymlinks'
         title: "允許使用符號連結（symbolic link）"
         desc: "使用模糊尋找（fuzzy finder）時，允許尋找及開啟符號連結（symbolic link）所對應的檔案。"

--- a/def/zh-tw/settings.cson
+++ b/def/zh-tw/settings.cson
@@ -263,6 +263,11 @@ Settings:
         desc: "文字編輯器內文字的行高，為字型大小的倍數。"
       }
       {
+        _id: 'editor.maxScreenLineLength'
+        title: "視窗顯示的每行最大長度"
+        desc: "不會套用自動換行的編輯器視窗寬度最大值，以字元數來表示。"
+      }
+      {
         _id: 'editor.nonWordCharacters'
         title: "不視為詞彙的字元"
         desc: "下列字元將不被視為詞彙，而是拿來做為詞彙邊界。"

--- a/spec/config.js
+++ b/spec/config.js
@@ -8,7 +8,7 @@ const CSON_FILES = [
   'welcome.cson',
 ]
 
-const ATOM_VERSION = 'v1.21.0'
+const ATOM_VERSION = 'v1.22.0-beta0'
 
 module.exports = {
   CSON_FILES,

--- a/spec/config.js
+++ b/spec/config.js
@@ -8,7 +8,7 @@ const CSON_FILES = [
   'welcome.cson',
 ]
 
-const ATOM_VERSION = 'v1.19.0'
+const ATOM_VERSION = 'v1.20.1'
 
 module.exports = {
   CSON_FILES,

--- a/spec/config.js
+++ b/spec/config.js
@@ -8,7 +8,7 @@ const CSON_FILES = [
   'welcome.cson',
 ]
 
-const ATOM_VERSION = 'v1.20.1'
+const ATOM_VERSION = 'v1.21.0'
 
 module.exports = {
   CSON_FILES,

--- a/spec/validation.js
+++ b/spec/validation.js
@@ -39,16 +39,11 @@ describe('validation', () => {
 
     describe('checking template/settings.cson `controls.*._id` according atom config-schema.js', () => {
 
-      it('fetches config-schema.js then compares keys of settings.cson with it', async () => {
+      it('fetches descriptive part of config-schema.js then compares keys of settings.cson with it', async () => {
         const neverShownDesciptionInSettingsPanelItems = [
           'core.customFileTypes',
           'core.disabledPackages',
           'core.themes',
-          'editor.commentEnd',
-          'editor.commentStart',
-          'editor.decreaseIndentPattern',
-          'editor.foldEndPattern',
-          'editor.increaseIndentPattern',
           'editor.invisibles',   // NOTE shows only editor.invisibles.*
         ]    // NOTE Manually updated exceptional list from https://github.com/atom/settings-view/blob/master/lib/settings-panel.js#L339-L350
 
@@ -61,15 +56,20 @@ describe('validation', () => {
 
         const flattenSrcConfigKeys = await axios.get(configURL).then(({ data }) => {
           const srcConfig = eval(data)
+          const keysWithoutDescriptionToKeep = [
+            'core.autoHideMenuBar', // platform specific
+          ]
           return Object.keys(flattenObj(srcConfig))
             .filter(key => key.search(/enum/g) === -1)
-            .filter(key => key.search(/description$/g) > -1)
+            .filter(key => key.search(/description$/g) !== -1)
+            .concat(keysWithoutDescriptionToKeep)
             .map(key => key.replace(/\.properties/g, '').replace(/\.description/g, ''))
+            .sort()
         })
 
-        expect(templateSettingsControls.concat(neverShownDesciptionInSettingsPanelItems))
+        expect(templateSettingsControls.concat(neverShownDesciptionInSettingsPanelItems).sort())
           .to.include.members(flattenSrcConfigKeys, `inconsistent keys compared with ${configURL}\n`)
-        // NOTE expect every key `flattenSrcConfigKeys` appears in templateSettingsControls
+        // NOTE expect every key in `flattenSrcConfigKeys` appears in templateSettingsControls
       })
     })
 


### PR DESCRIPTION
- upgrade Atom version to **v1.20.1** -> passed validation
- upgrade Atom version **v1.21.0-beta1** -> failed validation (new config schema in v1.21)
    - added new schema `core.fileSystemWatcher`
    - translate new schema `core.fileSystemWatcher` in `zh-tw`
- upgrade Atom version **v1.22.0-beta0** -> failed validation (new config schema in v1.22.0-beta0)
    - added new schema `editor.maxScreenLineLength`
    - translate new schema `editor.maxScreenLineLength` in `zh-tw`