### PR TITLE
fix(welcome): don't set innerHTML when DOM query is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.13.2 - hotfix
+* fix null dom query #128
+
 ## 0.13.1 - Decaffeinate
 * fix null dom query #126
 * introduce greenkeeper-lockfile #125

--- a/lib/welcome.js
+++ b/lib/welcome.js
@@ -13,7 +13,7 @@ class Welcome {
     if (welcome.getAttribute('data-localized') !== 'true') {
       {
         const subtitle = welcome.querySelector('.welcome-header h1.welcome-title')
-        if (subtitle === null) {
+        if (subtitle) {
           let {text1, superscript, text2} = this.defW.Welcome.subtitle
           subtitle.innerHTML = `${text1}<sup>${superscript}</sup>${text2}`
         }


### PR DESCRIPTION
fixup PR #126 for issue #80  