### PR TITLE
fix French translation of pane:close

### DIFF
--- a/def/fr/context.cson
+++ b/def/fr/context.cson
@@ -16,13 +16,13 @@ Context:
     "pane:split-down-and-copy-active-item": "Dédoubler en bas"
     "pane:split-left-and-copy-active-item": "Dédoubler à gauche"
     "pane:split-right-and-copy-active-item": "Dédoubler à droite"
-    "pane:close": "Fermer l'onglet"
+    "pane:close": "Fermer le carreau"
   "atom-pane":
     "pane:split-up-and-copy-active-item": "Dédoubler en haut"
     "pane:split-down-and-copy-active-item": "Dédoubler en bas"
     "pane:split-left-and-copy-active-item": "Dédoubler à gauche"
     "pane:split-right-and-copy-active-item": "Dédoubler à droite"
-    "pane:close": "Fermer l'onglet"
+    "pane:close": "Fermer le carreau"
   "atom-text-editor:not([mini])":
     "encoding-selector:show": "Changer l'encodage"
     "spell-check:correct-misspelling": "Corriger l'orthographe"


### PR DESCRIPTION
The original translation meant "close tab," not "close pane," which was misleading since `pane:close` closes all the tabs in the selected pane, not just the visible tab (which is what `tab:close-tab` does).

This PR/Translation is about #ISSUE_NUMBER.

**files translated**:
  - [ ] `def/--LOCALE-CODE--/about.cson`
  - [x] `def/--LOCALE-CODE--/context.cson`
  - [ ] `def/--LOCALE-CODE--/menu_darwin.cson`
  - [ ] `def/--LOCALE-CODE--/menu_linux.cson`
  - [ ] `def/--LOCALE-CODE--/menu_win32.cson`
  - [ ] `def/--LOCALE-CODE--/settings.cson`
  - [ ] `def/--LOCALE-CODE--/welcome.cson`

**validation**
  - [ ] I've validated my translation locally by running

`npm run validation -- --locale MY_LOCALE`
