### PR TITLE
Fix issue #156 (No checkbox at welcome screen)

### DIFF
--- a/lib/welcome.js
+++ b/lib/welcome.js
@@ -46,7 +46,8 @@ class Welcome {
       }
       const label = welcome.querySelector('label')
       if (label) {
-        label.textContent = this.defW.Welcome.showWelcomeGuide
+        // Checkbox is the 1st [0] node; label is the 2nd [1] node.
+        label.childNodes[1].textContent = this.defW.Welcome.showWelcomeGuide
       }
 
       return welcome.setAttribute('data-localized', 'true')


### PR DESCRIPTION
This patch prevents the label node from being overwritten by all languages of atom-i18n.
Users can now enable/disable the welcome page directly from the GUI.

This BUGFIX is about issue #156 (reported by @nolt, help requested by @liuderchi on 8 mar 2018).

- Great software deserves a great UX. -

**files translated**: NONE
**validation**: TESTED
