### PR TITLE
Not translate Settings tab when reopen

### DIFF
--- a/lib/preferences.js
+++ b/lib/preferences.js
@@ -31,15 +31,9 @@ class Preferences {
       window.I18N.pref.done = true
 
       // Restore the flag when the settings panel is closed
-      const editorPane = atom.workspace.getActivePane()
-      if (editorPane) {
-        let handler
-        return handler = editorPane.onDidRemoveItem(event => {
-          if (event.item.uri === 'atom://config') {
-            window.I18N.pref.done = false
-          }
-          return handler.dispose()
-        })
+      const ediotrPaneItem = atom.workspace.getActivePaneItem()
+      if (ediotrPaneItem.uri === 'atom://config') {
+        window.I18N.pref.done = false
       }
     } catch (e) {
       console.error(`I18N failed with locale ${atom.config.get('atom-i18n.locale')}: `, e)

--- a/lib/preferences.js
+++ b/lib/preferences.js
@@ -29,6 +29,18 @@ class Preferences {
       }
 
       window.I18N.pref.done = true
+
+      // Restore the flag when the settings panel is closed
+      const editorPane = atom.workspace.getActivePane()
+      if (editorPane) {
+        let handler
+        return handler = editorPane.onDidRemoveItem(event => {
+          if (event.item.uri === 'atom://config') {
+            window.I18N.pref.done = false
+          }
+          return handler.dispose()
+        })
+      }
     } catch (e) {
       console.error(`I18N failed with locale ${atom.config.get('atom-i18n.locale')}: `, e)
     }


### PR DESCRIPTION
This PR is about #97 .

**files translated**:
  - [x] `lib/preferences.js`

**validation**
  - [x] I've validated my translation locally by running

`npm run validation --`

This code came from syon/atom-japanese-menu#21