### PR TITLE
Fix Japanese translation of update message

### DIFF
--- a/def/ja/settings.cson
+++ b/def/ja/settings.cson
@@ -407,8 +407,8 @@ Settings:
     searchBarText: 'テーマを名前でフィルタリング'
   }
   updates: {
-    "check-updates": "すべてアップデート"
-    "update-all": "アップデートをチェック"
+    "check-updates": "アップデートをチェック"
+    "update-all": "すべてアップデート"
     "checking-updates": "アップデートを確認中..."
     "all-updated-message": "インストールしたパッケージはすべて最新です！"
   }


### PR DESCRIPTION
This PR has fixed the Japanese translation of the update message.
"check-updates" and "update-all" were reversed, so I fixed it.