### PR TITLE
Update zh-tw translations

### DIFF
--- a/def/zh-tw/context.cson
+++ b/def/zh-tw/context.cson
@@ -49,7 +49,7 @@ Context:
   ".tab-bar":
     "pane:reopen-closed-item": "重新開啟關閉分頁"
   ".tree-view .full-menu":
-    "tree-view:add-file": "新增文件"
+    "tree-view:add-file": "新增檔案"
     "tree-view:add-folder": "新增資料夾"
     "tree-view:move": "移動/重新命名"
     "tree-view:duplicate": "建立副本"
@@ -71,7 +71,7 @@ Context:
     "tree-view:open-selected-entry-left": "向左分割窗格並開啟 ←"
     "tree-view:open-selected-entry-right": "向右分割窗格並開啟 →"
   ".tree-view .full-menu .project-root > .header":
-    "tree-view:add-file": "新增文件"
+    "tree-view:add-file": "新增檔案"
     "tree-view:add-folder": "新增資料夾"
     "tree-view:move": "移動/重新命名"
     "tree-view:duplicate": "建立副本"

--- a/def/zh-tw/menu_darwin.cson
+++ b/def/zh-tw/menu_darwin.cson
@@ -36,7 +36,7 @@ Menu:
       "New Window":
         value: "開新視窗"
       "New File":
-        value: "新增文件"
+        value: "新增檔案"
       "Open…":
         value: "開啟..."
       "Add Project Folder…":
@@ -47,7 +47,7 @@ Menu:
           "Clear Project History":
             value: "清除專案歷史紀錄"
       "Reopen Last Item":
-        value: "重新開啟關閉的文件"
+        value: "重新開啟關閉的檔案"
       Save:
         value: "儲存"
       "Save As…":
@@ -305,7 +305,7 @@ Menu:
       "Bring All to Front":
         value: "全部移至最上層"
   Help:
-    value: "幫助"
+    value: "說明"
     submenu:
       "Terms of Use":
         value: "使用條款"

--- a/def/zh-tw/menu_linux.cson
+++ b/def/zh-tw/menu_linux.cson
@@ -5,7 +5,7 @@ Menu:
       "New &Window":
         value: "開新視窗(&W)"
       "&New File":
-        value: "新增文件(&N)"
+        value: "新增檔案(&N)"
       "&Open File…":
         value: "開啟(&O)..."
       "Open Folder…":
@@ -24,7 +24,7 @@ Menu:
       "Save &As…":
         value: "另存新檔(&A)..."
       "Save A&ll":
-        value: "儲存所有文件(&L)"
+        value: "儲存所有檔案(&L)"
       "&Close Tab":
         value: "關閉分頁(&C)"
       "Close &Pane":
@@ -283,7 +283,7 @@ Menu:
   "&Packages":
     value: "擴充套件(&P)"
   "&Help":
-    value: "幫助(&H)"
+    value: "說明(&H)"
     submenu:
       "View &Terms of Use":
         value: "檢視使用條款(&T)"

--- a/def/zh-tw/menu_win32.cson
+++ b/def/zh-tw/menu_win32.cson
@@ -5,7 +5,7 @@ Menu:
       "New &Window":
         value: "開新視窗(&W)"
       "&New File":
-        value: "新增文件(&N)"
+        value: "新增檔案(&N)"
       "&Open File…":
         value: "開啟(&O)..."
       "Open Folder…":
@@ -36,7 +36,7 @@ Menu:
       "Save &As…":
         value: "另存新檔(&A)..."
       "Save A&ll":
-        value: "儲存所有文件(&L)"
+        value: "儲存所有檔案(&L)"
       "&Close Tab":
         value: "關閉分頁(&C)"
       "Close &Pane":
@@ -259,9 +259,9 @@ Menu:
       "Replace in Buffer":
         value: "在文件中取代"
       "Select Next":
-        value: "選擇下一個項目"
+        value: "選取下一個項目"
       "Select All":
-        value: "選擇所有項目"
+        value: "選取所有項目"
       "Toggle Find in Buffer":
         value: "切換文件中尋找面板"
       "Find in Project":
@@ -289,7 +289,7 @@ Menu:
   "&Packages":
     value: "擴充套件(&P)"
   "&Help":
-    value: "幫助(&H)"
+    value: "說明(&H)"
     submenu:
       "View &Terms of Use":
         value: "檢視使用條款(&T)"
@@ -300,9 +300,9 @@ Menu:
       "Check for Update":
         value: "檢查更新"
       "Checking for Update":
-        value: "Checking for Update"
+        value: "正在檢查更新"
       "Downloading Update":
-        value: "Downloading Update"
+        value: "正在下載更新"
       "&Documentation":
         value: "說明文件(&D)"
       "Frequently Asked Questions":

--- a/def/zh-tw/welcome.cson
+++ b/def/zh-tw/welcome.cson
@@ -6,7 +6,7 @@ Welcome:
     text2: ""
   }
   help: {
-    forHelpVisit: "若需要幫助，請拜訪"
+    forHelpVisit: "若需要協助，請造訪"
     atomDocs: {
       text1: ""
       link: "Atom 文件"
@@ -21,7 +21,7 @@ Welcome:
     }
     atomOrg: {
       text1: ""
-      link: "Atom 組織"
+      link: "Atom 網站"
       text2: "。這裡包含所有 GitHub 所開發的 Atom 擴充套件。"
       _template: "${text1}<a>${link}</a>${text2}"
     }


### PR DESCRIPTION
This PR/Translation is for zh-tw - Chinese(Traditional).

**files translated**:
  - [x] `def/zh-tw/about.cson`
  - [x] `def/zh-tw/context.cson`
  - [x] `def/zh-tw/menu_darwin.cson`
  - [x] `def/zh-tw/menu_linux.cson`
  - [x] `def/zh-tw/menu_win32.cson`
  - [x] `def/zh-tw/settings.cson`
  - [x] `def/zh-tw/welcome.cson`

**files translation updated**:
  - [ ] `def/zh-tw/about.cson`
  - [x] `def/zh-tw/context.cson`
  - [x] `def/zh-tw/menu_darwin.cson`
  - [x] `def/zh-tw/menu_linux.cson`
  - [x] `def/zh-tw/menu_win32.cson`
  - [ ] `def/zh-tw/settings.cson`
  - [x] `def/zh-tw/welcome.cson`

**validation**
  - [x] I've validated my translation locally by running

`npm run validation -- --locale MY_LOCALE`
