### PR TITLE
Add features to localize Welcome-Guide and Telemetry-Consent

### DIFF
--- a/def/ar/consent.cson
+++ b/def/ar/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "Telemetry Consent"
+  desc:
+    text1: "Help improve Atom by sending your anonymous "
+    text2: "usage data"
+    text3: " to the Atom team. The resulting data plays a key role in deciding what we focus on next."
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "Yes, send my usage data"
+    notes:
+      text1: "Including exception and crash reports. See the "
+      text2: "atom/metrics package"
+      text3: " for more details."
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "No, do not send my usage data"
+    notes: "Note: We only register anonymously that you opted-out."
+  with: " with "
+  by: " by "

--- a/def/ar/guide.cson
+++ b/def/ar/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "Welcome Guide"
+  subTitle: "Get to know Atom!"
+  project:
+    title:
+      text1: "Open a "
+      text2: "Project"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "In Atom you can open individual files or a whole folder as a project. 
+             Opening a folder will add a tree view to the editor where you can browse all the files."
+    'open-project': "Open a Project"
+    note:
+      text1: "Next time:"
+      text2: " You can also open projects from the menu, keyboard shortcut or by dragging a folder onto the Atom dock icon."
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: "Version control with "
+      text2: "Git and GitHub"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Track changes to your code as you work. Branch, commit, push, and pull without leaving the comfort of your editor.
+             Collaborate with other developers on GitHub."
+    'open-git': "Open the Git panel"
+    'open-github': "Open the GitHub panel"
+    note:
+      text1: "Next time:"
+      text2: " You can toggle the Git tab by clicking on the "
+      text3: " button in your status bar."
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: "Collaborate in real time with "
+      text2: "Teletype"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Share your workspace with team members and collaborate on code in real time."
+    'install-teletype': "Install Teletype for Atom"
+  packages:
+    title:
+      text1: "Install a "
+      text2: "Package"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "One of the best things about Atom is the package ecosystem.
+             Installing packages adds new features and functionality you can use to make the editor suit your needs. Let's install one."
+    'install-package': "Open Installer"
+    note:
+      text1: "Next time:"
+      text2: " You can install new packages from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: "Choose a "
+      text2: "Theme"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom comes with preinstalled themes. Let's try a few."
+    'open-theme': "Open the theme picker"
+    detail2: "You can also install themes created by the Atom community. 
+              To install new themes, click on \"+ Install\" and switch the toggle to \"themes\"."
+    note:
+      text1: "Next time:"
+      text2: " You can switch themes from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: "Customize the "
+      text2: "Styling"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "You can customize almost anything by adding your own CSS/LESS." 
+    'open-stylesheet': "Open your Stylesheet"
+    detail2: "Now uncomment some of the examples or try your own" 
+    note:
+      text1: "Next time:"
+      text2: " You can open your stylesheet from Menu File."
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: "Hack on the "
+      text2: "Init Script"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "The init script is a bit of JavaScript or CoffeeScript run at startup. You can use it to quickly change the behaviour of Atom."
+    'open-init-script': "Open your Init Script"
+    detail2: "Uncomment some of the examples or try out your own." 
+    note:
+      text1: "Next time:"
+      text2: " You can open your init script from Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: "Add a "
+      text2: "Snippet"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom snippets allow you to enter a simple prefix in the editor and hit tab to expand the prefix into a larger code block with templated values."
+    'open-snippet': "Open your Snippets"
+    detail2: "In your snippets file, type <code>snip</code> then hit <code>tab</code>. The <code>snip</code> snippet will expand to create a snippet!"
+    note:
+      text1: "Next time:"
+      text2: " You can open your snippets in Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: "Learn "
+      text2: "Keyboard Shortcuts"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "If you only remember one keyboard shortcut make it "
+      text2: ". This keystroke toggles the command palette, which lists every Atom command.
+              It's a good way to learn more shortcuts. Yes, you can try it now!"
+      text3: "If you want to use these guides again use the command palette "
+      text4: " and search for "
+      text5: "Welcome"
+      text6: "."
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/ar/welcome.cson
+++ b/def/ar/welcome.cson
@@ -1,29 +1,24 @@
 Welcome:
   tabTitle: "مرحبا"
-  subtitle: {
+  subtitle:
     text1: "محرر ملفات قابل للإختراق من أجل القرن الحادي والعشرين"
     superscript: ""
     text2: ""
-  }
-  help: {
+  help:
     forHelpVisit: "للمساعدة، فضلا زر"
-    atomDocs: {
+    atomDocs:
       text1: ""
       link: "توثيقات أتوم"
       text2: " من أجل الإرشادات ومرجع واجهة برمجة التطبيق."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomForum: {
+    atomForum:
       text1: "منتدى أتوم في "
       link: "discuss.atom.io"
       text2: ""   # optional
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomOrg: {
+    atomOrg:
       text1: ""
       link: "منظمة أتوم"
       text2: "حيث يمكن إيجاد كاقة حزم أتوم المصنعة بواسطة جيتهب."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-  }
   showWelcomeGuide: "إعرض دليل الترحيب عند فتح أتوم"

--- a/def/be/consent.cson
+++ b/def/be/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "Telemetry Consent"
+  desc:
+    text1: "Help improve Atom by sending your anonymous "
+    text2: "usage data"
+    text3: " to the Atom team. The resulting data plays a key role in deciding what we focus on next."
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "Yes, send my usage data"
+    notes:
+      text1: "Including exception and crash reports. See the "
+      text2: "atom/metrics package"
+      text3: " for more details."
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "No, do not send my usage data"
+    notes: "Note: We only register anonymously that you opted-out."
+  with: " with "
+  by: " by "

--- a/def/be/guide.cson
+++ b/def/be/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "Welcome Guide"
+  subTitle: "Get to know Atom!"
+  project:
+    title:
+      text1: "Open a "
+      text2: "Project"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "In Atom you can open individual files or a whole folder as a project. 
+             Opening a folder will add a tree view to the editor where you can browse all the files."
+    'open-project': "Open a Project"
+    note:
+      text1: "Next time:"
+      text2: " You can also open projects from the menu, keyboard shortcut or by dragging a folder onto the Atom dock icon."
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: "Version control with "
+      text2: "Git and GitHub"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Track changes to your code as you work. Branch, commit, push, and pull without leaving the comfort of your editor.
+             Collaborate with other developers on GitHub."
+    'open-git': "Open the Git panel"
+    'open-github': "Open the GitHub panel"
+    note:
+      text1: "Next time:"
+      text2: " You can toggle the Git tab by clicking on the "
+      text3: " button in your status bar."
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: "Collaborate in real time with "
+      text2: "Teletype"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Share your workspace with team members and collaborate on code in real time."
+    'install-teletype': "Install Teletype for Atom"
+  packages:
+    title:
+      text1: "Install a "
+      text2: "Package"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "One of the best things about Atom is the package ecosystem.
+             Installing packages adds new features and functionality you can use to make the editor suit your needs. Let's install one."
+    'install-package': "Open Installer"
+    note:
+      text1: "Next time:"
+      text2: " You can install new packages from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: "Choose a "
+      text2: "Theme"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom comes with preinstalled themes. Let's try a few."
+    'open-theme': "Open the theme picker"
+    detail2: "You can also install themes created by the Atom community. 
+              To install new themes, click on \"+ Install\" and switch the toggle to \"themes\"."
+    note:
+      text1: "Next time:"
+      text2: " You can switch themes from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: "Customize the "
+      text2: "Styling"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "You can customize almost anything by adding your own CSS/LESS." 
+    'open-stylesheet': "Open your Stylesheet"
+    detail2: "Now uncomment some of the examples or try your own" 
+    note:
+      text1: "Next time:"
+      text2: " You can open your stylesheet from Menu File."
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: "Hack on the "
+      text2: "Init Script"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "The init script is a bit of JavaScript or CoffeeScript run at startup. You can use it to quickly change the behaviour of Atom."
+    'open-init-script': "Open your Init Script"
+    detail2: "Uncomment some of the examples or try out your own." 
+    note:
+      text1: "Next time:"
+      text2: " You can open your init script from Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: "Add a "
+      text2: "Snippet"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom snippets allow you to enter a simple prefix in the editor and hit tab to expand the prefix into a larger code block with templated values."
+    'open-snippet': "Open your Snippets"
+    detail2: "In your snippets file, type <code>snip</code> then hit <code>tab</code>. The <code>snip</code> snippet will expand to create a snippet!"
+    note:
+      text1: "Next time:"
+      text2: " You can open your snippets in Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: "Learn "
+      text2: "Keyboard Shortcuts"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "If you only remember one keyboard shortcut make it "
+      text2: ". This keystroke toggles the command palette, which lists every Atom command.
+              It's a good way to learn more shortcuts. Yes, you can try it now!"
+      text3: "If you want to use these guides again use the command palette "
+      text4: " and search for "
+      text5: "Welcome"
+      text6: "."
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/cs/consent.cson
+++ b/def/cs/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "Telemetry Consent"
+  desc:
+    text1: "Help improve Atom by sending your anonymous "
+    text2: "usage data"
+    text3: " to the Atom team. The resulting data plays a key role in deciding what we focus on next."
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "Yes, send my usage data"
+    notes:
+      text1: "Including exception and crash reports. See the "
+      text2: "atom/metrics package"
+      text3: " for more details."
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "No, do not send my usage data"
+    notes: "Note: We only register anonymously that you opted-out."
+  with: " with "
+  by: " by "

--- a/def/cs/guide.cson
+++ b/def/cs/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "Welcome Guide"
+  subTitle: "Get to know Atom!"
+  project:
+    title:
+      text1: "Open a "
+      text2: "Project"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "In Atom you can open individual files or a whole folder as a project. 
+             Opening a folder will add a tree view to the editor where you can browse all the files."
+    'open-project': "Open a Project"
+    note:
+      text1: "Next time:"
+      text2: " You can also open projects from the menu, keyboard shortcut or by dragging a folder onto the Atom dock icon."
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: "Version control with "
+      text2: "Git and GitHub"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Track changes to your code as you work. Branch, commit, push, and pull without leaving the comfort of your editor.
+             Collaborate with other developers on GitHub."
+    'open-git': "Open the Git panel"
+    'open-github': "Open the GitHub panel"
+    note:
+      text1: "Next time:"
+      text2: " You can toggle the Git tab by clicking on the "
+      text3: " button in your status bar."
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: "Collaborate in real time with "
+      text2: "Teletype"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Share your workspace with team members and collaborate on code in real time."
+    'install-teletype': "Install Teletype for Atom"
+  packages:
+    title:
+      text1: "Install a "
+      text2: "Package"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "One of the best things about Atom is the package ecosystem.
+             Installing packages adds new features and functionality you can use to make the editor suit your needs. Let's install one."
+    'install-package': "Open Installer"
+    note:
+      text1: "Next time:"
+      text2: " You can install new packages from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: "Choose a "
+      text2: "Theme"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom comes with preinstalled themes. Let's try a few."
+    'open-theme': "Open the theme picker"
+    detail2: "You can also install themes created by the Atom community. 
+              To install new themes, click on \"+ Install\" and switch the toggle to \"themes\"."
+    note:
+      text1: "Next time:"
+      text2: " You can switch themes from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: "Customize the "
+      text2: "Styling"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "You can customize almost anything by adding your own CSS/LESS." 
+    'open-stylesheet': "Open your Stylesheet"
+    detail2: "Now uncomment some of the examples or try your own" 
+    note:
+      text1: "Next time:"
+      text2: " You can open your stylesheet from Menu File."
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: "Hack on the "
+      text2: "Init Script"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "The init script is a bit of JavaScript or CoffeeScript run at startup. You can use it to quickly change the behaviour of Atom."
+    'open-init-script': "Open your Init Script"
+    detail2: "Uncomment some of the examples or try out your own." 
+    note:
+      text1: "Next time:"
+      text2: " You can open your init script from Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: "Add a "
+      text2: "Snippet"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom snippets allow you to enter a simple prefix in the editor and hit tab to expand the prefix into a larger code block with templated values."
+    'open-snippet': "Open your Snippets"
+    detail2: "In your snippets file, type <code>snip</code> then hit <code>tab</code>. The <code>snip</code> snippet will expand to create a snippet!"
+    note:
+      text1: "Next time:"
+      text2: " You can open your snippets in Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: "Learn "
+      text2: "Keyboard Shortcuts"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "If you only remember one keyboard shortcut make it "
+      text2: ". This keystroke toggles the command palette, which lists every Atom command.
+              It's a good way to learn more shortcuts. Yes, you can try it now!"
+      text3: "If you want to use these guides again use the command palette "
+      text4: " and search for "
+      text5: "Welcome"
+      text6: "."
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/cs/welcome.cson
+++ b/def/cs/welcome.cson
@@ -1,29 +1,24 @@
 Welcome:
   tabTitle: "Vítejte"
-  subtitle: {
+  subtitle:
     text1: "Modifikovatelný editor pro 21."
     superscript: ""
     text2: " století"
-  }
-  help: {
+  help:
     forHelpVisit: "Pro pomoc prosím navštivte"
-    atomDocs: {
+    atomDocs:
       text1: ""
       link: "Dokumentaci atomu"
       text2: " pro Návody a reference API."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomForum: {
+    atomForum:
       text1: "Fórum atomu na: "
       link: "discuss.atom.io"
       text2: ""   # optional
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomOrg: {
+    atomOrg:
       text1: ""
       link: "Organizaci Atom"
       text2: ". Zde najdete všechny balíčky Atom na GitHubu."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-  }
   showWelcomeGuide: "Zobrazit uvítacího průvodce při spuštění Atomu"

--- a/def/de/consent.cson
+++ b/def/de/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "Telemetry Consent"
+  desc:
+    text1: "Help improve Atom by sending your anonymous "
+    text2: "usage data"
+    text3: " to the Atom team. The resulting data plays a key role in deciding what we focus on next."
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "Yes, send my usage data"
+    notes:
+      text1: "Including exception and crash reports. See the "
+      text2: "atom/metrics package"
+      text3: " for more details."
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "No, do not send my usage data"
+    notes: "Note: We only register anonymously that you opted-out."
+  with: " with "
+  by: " by "

--- a/def/de/guide.cson
+++ b/def/de/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "Welcome Guide"
+  subTitle: "Get to know Atom!"
+  project:
+    title:
+      text1: "Open a "
+      text2: "Project"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "In Atom you can open individual files or a whole folder as a project. 
+             Opening a folder will add a tree view to the editor where you can browse all the files."
+    'open-project': "Open a Project"
+    note:
+      text1: "Next time:"
+      text2: " You can also open projects from the menu, keyboard shortcut or by dragging a folder onto the Atom dock icon."
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: "Version control with "
+      text2: "Git and GitHub"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Track changes to your code as you work. Branch, commit, push, and pull without leaving the comfort of your editor.
+             Collaborate with other developers on GitHub."
+    'open-git': "Open the Git panel"
+    'open-github': "Open the GitHub panel"
+    note:
+      text1: "Next time:"
+      text2: " You can toggle the Git tab by clicking on the "
+      text3: " button in your status bar."
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: "Collaborate in real time with "
+      text2: "Teletype"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Share your workspace with team members and collaborate on code in real time."
+    'install-teletype': "Install Teletype for Atom"
+  packages:
+    title:
+      text1: "Install a "
+      text2: "Package"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "One of the best things about Atom is the package ecosystem.
+             Installing packages adds new features and functionality you can use to make the editor suit your needs. Let's install one."
+    'install-package': "Open Installer"
+    note:
+      text1: "Next time:"
+      text2: " You can install new packages from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: "Choose a "
+      text2: "Theme"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom comes with preinstalled themes. Let's try a few."
+    'open-theme': "Open the theme picker"
+    detail2: "You can also install themes created by the Atom community. 
+              To install new themes, click on \"+ Install\" and switch the toggle to \"themes\"."
+    note:
+      text1: "Next time:"
+      text2: " You can switch themes from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: "Customize the "
+      text2: "Styling"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "You can customize almost anything by adding your own CSS/LESS." 
+    'open-stylesheet': "Open your Stylesheet"
+    detail2: "Now uncomment some of the examples or try your own" 
+    note:
+      text1: "Next time:"
+      text2: " You can open your stylesheet from Menu File."
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: "Hack on the "
+      text2: "Init Script"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "The init script is a bit of JavaScript or CoffeeScript run at startup. You can use it to quickly change the behaviour of Atom."
+    'open-init-script': "Open your Init Script"
+    detail2: "Uncomment some of the examples or try out your own." 
+    note:
+      text1: "Next time:"
+      text2: " You can open your init script from Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: "Add a "
+      text2: "Snippet"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom snippets allow you to enter a simple prefix in the editor and hit tab to expand the prefix into a larger code block with templated values."
+    'open-snippet': "Open your Snippets"
+    detail2: "In your snippets file, type <code>snip</code> then hit <code>tab</code>. The <code>snip</code> snippet will expand to create a snippet!"
+    note:
+      text1: "Next time:"
+      text2: " You can open your snippets in Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: "Learn "
+      text2: "Keyboard Shortcuts"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "If you only remember one keyboard shortcut make it "
+      text2: ". This keystroke toggles the command palette, which lists every Atom command.
+              It's a good way to learn more shortcuts. Yes, you can try it now!"
+      text3: "If you want to use these guides again use the command palette "
+      text4: " and search for "
+      text5: "Welcome"
+      text6: "."
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/de/welcome.cson
+++ b/def/de/welcome.cson
@@ -1,29 +1,24 @@
 Welcome:
   tabTitle: "Welcome"
-  subtitle: {
+  subtitle:
     text1: "Ein hackbarer Texteditor für das 21."
     superscript: ""
     text2: " Jahrhundert"
-  }
-  help: {
+  help:
     forHelpVisit: "Für Hilfe besuche bitte"
-    atomDocs: {
+    atomDocs:
       text1: "Die "
       link: "Atom-Doku"
       text2: " für Anleitungen und die API-Referenz."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomForum: {
+    atomForum:
       text1: "Das Atom-Forum unter "
       link: "discuss.atom.io"
       text2: ""   # optional
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomOrg: {
+    atomOrg:
       text1: "Die Seite "
       link: "Atom"
       text2: ". Hier sind alle über GitHub erzeugten Atom-Packages zu finden."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-  }
   showWelcomeGuide: "Willkommens-Seite beim Öffnen von Atom anzeigen"

--- a/def/eo/consent.cson
+++ b/def/eo/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "Telemetry Consent"
+  desc:
+    text1: "Help improve Atom by sending your anonymous "
+    text2: "usage data"
+    text3: " to the Atom team. The resulting data plays a key role in deciding what we focus on next."
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "Yes, send my usage data"
+    notes:
+      text1: "Including exception and crash reports. See the "
+      text2: "atom/metrics package"
+      text3: " for more details."
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "No, do not send my usage data"
+    notes: "Note: We only register anonymously that you opted-out."
+  with: " with "
+  by: " by "

--- a/def/eo/guide.cson
+++ b/def/eo/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "Welcome Guide"
+  subTitle: "Get to know Atom!"
+  project:
+    title:
+      text1: "Open a "
+      text2: "Project"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "In Atom you can open individual files or a whole folder as a project. 
+             Opening a folder will add a tree view to the editor where you can browse all the files."
+    'open-project': "Open a Project"
+    note:
+      text1: "Next time:"
+      text2: " You can also open projects from the menu, keyboard shortcut or by dragging a folder onto the Atom dock icon."
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: "Version control with "
+      text2: "Git and GitHub"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Track changes to your code as you work. Branch, commit, push, and pull without leaving the comfort of your editor.
+             Collaborate with other developers on GitHub."
+    'open-git': "Open the Git panel"
+    'open-github': "Open the GitHub panel"
+    note:
+      text1: "Next time:"
+      text2: " You can toggle the Git tab by clicking on the "
+      text3: " button in your status bar."
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: "Collaborate in real time with "
+      text2: "Teletype"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Share your workspace with team members and collaborate on code in real time."
+    'install-teletype': "Install Teletype for Atom"
+  packages:
+    title:
+      text1: "Install a "
+      text2: "Package"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "One of the best things about Atom is the package ecosystem.
+             Installing packages adds new features and functionality you can use to make the editor suit your needs. Let's install one."
+    'install-package': "Open Installer"
+    note:
+      text1: "Next time:"
+      text2: " You can install new packages from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: "Choose a "
+      text2: "Theme"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom comes with preinstalled themes. Let's try a few."
+    'open-theme': "Open the theme picker"
+    detail2: "You can also install themes created by the Atom community. 
+              To install new themes, click on \"+ Install\" and switch the toggle to \"themes\"."
+    note:
+      text1: "Next time:"
+      text2: " You can switch themes from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: "Customize the "
+      text2: "Styling"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "You can customize almost anything by adding your own CSS/LESS." 
+    'open-stylesheet': "Open your Stylesheet"
+    detail2: "Now uncomment some of the examples or try your own" 
+    note:
+      text1: "Next time:"
+      text2: " You can open your stylesheet from Menu File."
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: "Hack on the "
+      text2: "Init Script"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "The init script is a bit of JavaScript or CoffeeScript run at startup. You can use it to quickly change the behaviour of Atom."
+    'open-init-script': "Open your Init Script"
+    detail2: "Uncomment some of the examples or try out your own." 
+    note:
+      text1: "Next time:"
+      text2: " You can open your init script from Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: "Add a "
+      text2: "Snippet"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom snippets allow you to enter a simple prefix in the editor and hit tab to expand the prefix into a larger code block with templated values."
+    'open-snippet': "Open your Snippets"
+    detail2: "In your snippets file, type <code>snip</code> then hit <code>tab</code>. The <code>snip</code> snippet will expand to create a snippet!"
+    note:
+      text1: "Next time:"
+      text2: " You can open your snippets in Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: "Learn "
+      text2: "Keyboard Shortcuts"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "If you only remember one keyboard shortcut make it "
+      text2: ". This keystroke toggles the command palette, which lists every Atom command.
+              It's a good way to learn more shortcuts. Yes, you can try it now!"
+      text3: "If you want to use these guides again use the command palette "
+      text4: " and search for "
+      text5: "Welcome"
+      text6: "."
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/eo/welcome.cson
+++ b/def/eo/welcome.cson
@@ -1,29 +1,24 @@
 Welcome:
   tabTitle: "Welcome"
-  subtitle: {
+  subtitle:
     text1: "A hackable text editor for the 21"
     superscript: "st"
     text2: " Century"
-  }
-  help: {
+  help:
     forHelpVisit: "For help, please visit"
-    atomDocs: {
+    atomDocs:
       text1: "The "
       link: "Atom docs"
       text2: " for Guides and the API reference."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomForum: {
+    atomForum:
       text1: "The Atom forum at "
       link: "discuss.atom.io"
       text2: ""   # optional
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomOrg: {
+    atomOrg:
       text1: "The "
       link: "Atom org"
       text2: ". This is where all GitHub-created Atom packages can be found."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-  }
   showWelcomeGuide: "Show Welcome Guide when opening Atom"

--- a/def/es/consent.cson
+++ b/def/es/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "Telemetry Consent"
+  desc:
+    text1: "Help improve Atom by sending your anonymous "
+    text2: "usage data"
+    text3: " to the Atom team. The resulting data plays a key role in deciding what we focus on next."
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "Yes, send my usage data"
+    notes:
+      text1: "Including exception and crash reports. See the "
+      text2: "atom/metrics package"
+      text3: " for more details."
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "No, do not send my usage data"
+    notes: "Note: We only register anonymously that you opted-out."
+  with: " with "
+  by: " by "

--- a/def/es/guide.cson
+++ b/def/es/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "Welcome Guide"
+  subTitle: "Get to know Atom!"
+  project:
+    title:
+      text1: "Open a "
+      text2: "Project"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "In Atom you can open individual files or a whole folder as a project. 
+             Opening a folder will add a tree view to the editor where you can browse all the files."
+    'open-project': "Open a Project"
+    note:
+      text1: "Next time:"
+      text2: " You can also open projects from the menu, keyboard shortcut or by dragging a folder onto the Atom dock icon."
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: "Version control with "
+      text2: "Git and GitHub"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Track changes to your code as you work. Branch, commit, push, and pull without leaving the comfort of your editor.
+             Collaborate with other developers on GitHub."
+    'open-git': "Open the Git panel"
+    'open-github': "Open the GitHub panel"
+    note:
+      text1: "Next time:"
+      text2: " You can toggle the Git tab by clicking on the "
+      text3: " button in your status bar."
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: "Collaborate in real time with "
+      text2: "Teletype"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Share your workspace with team members and collaborate on code in real time."
+    'install-teletype': "Install Teletype for Atom"
+  packages:
+    title:
+      text1: "Install a "
+      text2: "Package"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "One of the best things about Atom is the package ecosystem.
+             Installing packages adds new features and functionality you can use to make the editor suit your needs. Let's install one."
+    'install-package': "Open Installer"
+    note:
+      text1: "Next time:"
+      text2: " You can install new packages from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: "Choose a "
+      text2: "Theme"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom comes with preinstalled themes. Let's try a few."
+    'open-theme': "Open the theme picker"
+    detail2: "You can also install themes created by the Atom community. 
+              To install new themes, click on \"+ Install\" and switch the toggle to \"themes\"."
+    note:
+      text1: "Next time:"
+      text2: " You can switch themes from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: "Customize the "
+      text2: "Styling"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "You can customize almost anything by adding your own CSS/LESS." 
+    'open-stylesheet': "Open your Stylesheet"
+    detail2: "Now uncomment some of the examples or try your own" 
+    note:
+      text1: "Next time:"
+      text2: " You can open your stylesheet from Menu File."
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: "Hack on the "
+      text2: "Init Script"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "The init script is a bit of JavaScript or CoffeeScript run at startup. You can use it to quickly change the behaviour of Atom."
+    'open-init-script': "Open your Init Script"
+    detail2: "Uncomment some of the examples or try out your own." 
+    note:
+      text1: "Next time:"
+      text2: " You can open your init script from Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: "Add a "
+      text2: "Snippet"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom snippets allow you to enter a simple prefix in the editor and hit tab to expand the prefix into a larger code block with templated values."
+    'open-snippet': "Open your Snippets"
+    detail2: "In your snippets file, type <code>snip</code> then hit <code>tab</code>. The <code>snip</code> snippet will expand to create a snippet!"
+    note:
+      text1: "Next time:"
+      text2: " You can open your snippets in Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: "Learn "
+      text2: "Keyboard Shortcuts"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "If you only remember one keyboard shortcut make it "
+      text2: ". This keystroke toggles the command palette, which lists every Atom command.
+              It's a good way to learn more shortcuts. Yes, you can try it now!"
+      text3: "If you want to use these guides again use the command palette "
+      text4: " and search for "
+      text5: "Welcome"
+      text6: "."
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/es/welcome.cson
+++ b/def/es/welcome.cson
@@ -1,29 +1,24 @@
 Welcome:
   tabTitle: "Welcome"
-  subtitle: {
+  subtitle:
     text1: "A hackable text editor for the 21"
     superscript: "st"
     text2: " Century"
-  }
-  help: {
+  help:
     forHelpVisit: "For help, please visit"
-    atomDocs: {
+    atomDocs:
       text1: "The "
       link: "Atom docs"
       text2: " for Guides and the API reference."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomForum: {
+    atomForum:
       text1: "The Atom forum at "
       link: "discuss.atom.io"
       text2: ""   # optional
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomOrg: {
+    atomOrg:
       text1: "The "
       link: "Atom org"
       text2: ". This is where all GitHub-created Atom packages can be found."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-  }
   showWelcomeGuide: "Show Welcome Guide when opening Atom"

--- a/def/fa/consent.cson
+++ b/def/fa/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "Telemetry Consent"
+  desc:
+    text1: "Help improve Atom by sending your anonymous "
+    text2: "usage data"
+    text3: " to the Atom team. The resulting data plays a key role in deciding what we focus on next."
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "Yes, send my usage data"
+    notes:
+      text1: "Including exception and crash reports. See the "
+      text2: "atom/metrics package"
+      text3: " for more details."
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "No, do not send my usage data"
+    notes: "Note: We only register anonymously that you opted-out."
+  with: " with "
+  by: " by "

--- a/def/fa/guide.cson
+++ b/def/fa/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "Welcome Guide"
+  subTitle: "Get to know Atom!"
+  project:
+    title:
+      text1: "Open a "
+      text2: "Project"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "In Atom you can open individual files or a whole folder as a project. 
+             Opening a folder will add a tree view to the editor where you can browse all the files."
+    'open-project': "Open a Project"
+    note:
+      text1: "Next time:"
+      text2: " You can also open projects from the menu, keyboard shortcut or by dragging a folder onto the Atom dock icon."
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: "Version control with "
+      text2: "Git and GitHub"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Track changes to your code as you work. Branch, commit, push, and pull without leaving the comfort of your editor.
+             Collaborate with other developers on GitHub."
+    'open-git': "Open the Git panel"
+    'open-github': "Open the GitHub panel"
+    note:
+      text1: "Next time:"
+      text2: " You can toggle the Git tab by clicking on the "
+      text3: " button in your status bar."
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: "Collaborate in real time with "
+      text2: "Teletype"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Share your workspace with team members and collaborate on code in real time."
+    'install-teletype': "Install Teletype for Atom"
+  packages:
+    title:
+      text1: "Install a "
+      text2: "Package"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "One of the best things about Atom is the package ecosystem.
+             Installing packages adds new features and functionality you can use to make the editor suit your needs. Let's install one."
+    'install-package': "Open Installer"
+    note:
+      text1: "Next time:"
+      text2: " You can install new packages from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: "Choose a "
+      text2: "Theme"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom comes with preinstalled themes. Let's try a few."
+    'open-theme': "Open the theme picker"
+    detail2: "You can also install themes created by the Atom community. 
+              To install new themes, click on \"+ Install\" and switch the toggle to \"themes\"."
+    note:
+      text1: "Next time:"
+      text2: " You can switch themes from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: "Customize the "
+      text2: "Styling"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "You can customize almost anything by adding your own CSS/LESS." 
+    'open-stylesheet': "Open your Stylesheet"
+    detail2: "Now uncomment some of the examples or try your own" 
+    note:
+      text1: "Next time:"
+      text2: " You can open your stylesheet from Menu File."
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: "Hack on the "
+      text2: "Init Script"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "The init script is a bit of JavaScript or CoffeeScript run at startup. You can use it to quickly change the behaviour of Atom."
+    'open-init-script': "Open your Init Script"
+    detail2: "Uncomment some of the examples or try out your own." 
+    note:
+      text1: "Next time:"
+      text2: " You can open your init script from Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: "Add a "
+      text2: "Snippet"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom snippets allow you to enter a simple prefix in the editor and hit tab to expand the prefix into a larger code block with templated values."
+    'open-snippet': "Open your Snippets"
+    detail2: "In your snippets file, type <code>snip</code> then hit <code>tab</code>. The <code>snip</code> snippet will expand to create a snippet!"
+    note:
+      text1: "Next time:"
+      text2: " You can open your snippets in Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: "Learn "
+      text2: "Keyboard Shortcuts"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "If you only remember one keyboard shortcut make it "
+      text2: ". This keystroke toggles the command palette, which lists every Atom command.
+              It's a good way to learn more shortcuts. Yes, you can try it now!"
+      text3: "If you want to use these guides again use the command palette "
+      text4: " and search for "
+      text5: "Welcome"
+      text6: "."
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/fa/welcome.cson
+++ b/def/fa/welcome.cson
@@ -1,29 +1,24 @@
 Welcome:
   tabTitle: "خوش آمدید"
-  subtitle: {
+  subtitle:
     text1: " ویرایشگر متن باحال و دوست داشتنی و هک شدنی (میتونی باهاش هرکاری بکنی) برای"
     superscript: "ام"
     text2: " قرن ۲۱"
-  }
-  help: {
+  help:
     forHelpVisit: "برای کمک گرفتن میتوانید به مکانهای زیر مراجعه کنید"
-    atomDocs: {
+    atomDocs:
       text1: "با مراجعه به "
       link: "مستندات اتم "
       text2: "میتوان راهنمایی گرفت و به مرجع API دسترسی داشت"
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomForum: {
+    atomForum:
       text1: "برای بحث و گفتگو میتوانید "
       link: "در فوروم اتم"
       text2: "بحث کنید "   # optional
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomOrg: {
+    atomOrg:
       text1: " همچنین، سایت رسمی"
       link: " موسسه غیرانتفاعی اتم"
       text2: " جایی است که میتوانید تمام پکیج های ساخته شده در گیت هاب برای اتم را بیابید."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-  }
   showWelcomeGuide: "راهنمای خوش آمد گویی هنگام باز شدن اتم نمایش داده شود"

--- a/def/fi/consent.cson
+++ b/def/fi/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "Telemetry Consent"
+  desc:
+    text1: "Help improve Atom by sending your anonymous "
+    text2: "usage data"
+    text3: " to the Atom team. The resulting data plays a key role in deciding what we focus on next."
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "Yes, send my usage data"
+    notes:
+      text1: "Including exception and crash reports. See the "
+      text2: "atom/metrics package"
+      text3: " for more details."
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "No, do not send my usage data"
+    notes: "Note: We only register anonymously that you opted-out."
+  with: " with "
+  by: " by "

--- a/def/fi/guide.cson
+++ b/def/fi/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "Welcome Guide"
+  subTitle: "Get to know Atom!"
+  project:
+    title:
+      text1: "Open a "
+      text2: "Project"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "In Atom you can open individual files or a whole folder as a project. 
+             Opening a folder will add a tree view to the editor where you can browse all the files."
+    'open-project': "Open a Project"
+    note:
+      text1: "Next time:"
+      text2: " You can also open projects from the menu, keyboard shortcut or by dragging a folder onto the Atom dock icon."
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: "Version control with "
+      text2: "Git and GitHub"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Track changes to your code as you work. Branch, commit, push, and pull without leaving the comfort of your editor.
+             Collaborate with other developers on GitHub."
+    'open-git': "Open the Git panel"
+    'open-github': "Open the GitHub panel"
+    note:
+      text1: "Next time:"
+      text2: " You can toggle the Git tab by clicking on the "
+      text3: " button in your status bar."
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: "Collaborate in real time with "
+      text2: "Teletype"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Share your workspace with team members and collaborate on code in real time."
+    'install-teletype': "Install Teletype for Atom"
+  packages:
+    title:
+      text1: "Install a "
+      text2: "Package"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "One of the best things about Atom is the package ecosystem.
+             Installing packages adds new features and functionality you can use to make the editor suit your needs. Let's install one."
+    'install-package': "Open Installer"
+    note:
+      text1: "Next time:"
+      text2: " You can install new packages from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: "Choose a "
+      text2: "Theme"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom comes with preinstalled themes. Let's try a few."
+    'open-theme': "Open the theme picker"
+    detail2: "You can also install themes created by the Atom community. 
+              To install new themes, click on \"+ Install\" and switch the toggle to \"themes\"."
+    note:
+      text1: "Next time:"
+      text2: " You can switch themes from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: "Customize the "
+      text2: "Styling"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "You can customize almost anything by adding your own CSS/LESS." 
+    'open-stylesheet': "Open your Stylesheet"
+    detail2: "Now uncomment some of the examples or try your own" 
+    note:
+      text1: "Next time:"
+      text2: " You can open your stylesheet from Menu File."
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: "Hack on the "
+      text2: "Init Script"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "The init script is a bit of JavaScript or CoffeeScript run at startup. You can use it to quickly change the behaviour of Atom."
+    'open-init-script': "Open your Init Script"
+    detail2: "Uncomment some of the examples or try out your own." 
+    note:
+      text1: "Next time:"
+      text2: " You can open your init script from Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: "Add a "
+      text2: "Snippet"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom snippets allow you to enter a simple prefix in the editor and hit tab to expand the prefix into a larger code block with templated values."
+    'open-snippet': "Open your Snippets"
+    detail2: "In your snippets file, type <code>snip</code> then hit <code>tab</code>. The <code>snip</code> snippet will expand to create a snippet!"
+    note:
+      text1: "Next time:"
+      text2: " You can open your snippets in Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: "Learn "
+      text2: "Keyboard Shortcuts"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "If you only remember one keyboard shortcut make it "
+      text2: ". This keystroke toggles the command palette, which lists every Atom command.
+              It's a good way to learn more shortcuts. Yes, you can try it now!"
+      text3: "If you want to use these guides again use the command palette "
+      text4: " and search for "
+      text5: "Welcome"
+      text6: "."
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/fi/welcome.cson
+++ b/def/fi/welcome.cson
@@ -1,29 +1,24 @@
 Welcome:
   tabTitle: "Tervetuloa"
-  subtitle: {
+  subtitle:
     text1: "Muokattava muokkain 21."
     superscript: ""
     text2: " vuosisadalle"
-  }
-  help: {
+  help:
     forHelpVisit: "Lisäohjeita saatavilla"
-    atomDocs: {
+    atomDocs:
       text1: ""
       link: "Atom-dokumentaatiosivulla"
       text2: ": oppaat ja rajapintakuvaus"
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomForum: {
+    atomForum:
       text1: "Atom-keskustelupalstalla osoitteessa "
       link: "discuss.atom.io"
       text2: ""   # optional
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomOrg: {
+    atomOrg:
       text1: "osoitteessa "
       link: "Atom.org"
       text2: ". Täältä löytyvät kaikki Githubin kautta saatavilla olevat Atom-paketit."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-  }
   showWelcomeGuide: "Näytä tervetulosivu, kun Atom avataan"

--- a/def/fr/consent.cson
+++ b/def/fr/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "Telemetry Consent"
+  desc:
+    text1: "Help improve Atom by sending your anonymous "
+    text2: "usage data"
+    text3: " to the Atom team. The resulting data plays a key role in deciding what we focus on next."
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "Yes, send my usage data"
+    notes:
+      text1: "Including exception and crash reports. See the "
+      text2: "atom/metrics package"
+      text3: " for more details."
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "No, do not send my usage data"
+    notes: "Note: We only register anonymously that you opted-out."
+  with: " with "
+  by: " by "

--- a/def/fr/guide.cson
+++ b/def/fr/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "Welcome Guide"
+  subTitle: "Get to know Atom!"
+  project:
+    title:
+      text1: "Open a "
+      text2: "Project"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "In Atom you can open individual files or a whole folder as a project. 
+             Opening a folder will add a tree view to the editor where you can browse all the files."
+    'open-project': "Open a Project"
+    note:
+      text1: "Next time:"
+      text2: " You can also open projects from the menu, keyboard shortcut or by dragging a folder onto the Atom dock icon."
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: "Version control with "
+      text2: "Git and GitHub"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Track changes to your code as you work. Branch, commit, push, and pull without leaving the comfort of your editor.
+             Collaborate with other developers on GitHub."
+    'open-git': "Open the Git panel"
+    'open-github': "Open the GitHub panel"
+    note:
+      text1: "Next time:"
+      text2: " You can toggle the Git tab by clicking on the "
+      text3: " button in your status bar."
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: "Collaborate in real time with "
+      text2: "Teletype"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Share your workspace with team members and collaborate on code in real time."
+    'install-teletype': "Install Teletype for Atom"
+  packages:
+    title:
+      text1: "Install a "
+      text2: "Package"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "One of the best things about Atom is the package ecosystem.
+             Installing packages adds new features and functionality you can use to make the editor suit your needs. Let's install one."
+    'install-package': "Open Installer"
+    note:
+      text1: "Next time:"
+      text2: " You can install new packages from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: "Choose a "
+      text2: "Theme"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom comes with preinstalled themes. Let's try a few."
+    'open-theme': "Open the theme picker"
+    detail2: "You can also install themes created by the Atom community. 
+              To install new themes, click on \"+ Install\" and switch the toggle to \"themes\"."
+    note:
+      text1: "Next time:"
+      text2: " You can switch themes from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: "Customize the "
+      text2: "Styling"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "You can customize almost anything by adding your own CSS/LESS." 
+    'open-stylesheet': "Open your Stylesheet"
+    detail2: "Now uncomment some of the examples or try your own" 
+    note:
+      text1: "Next time:"
+      text2: " You can open your stylesheet from Menu File."
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: "Hack on the "
+      text2: "Init Script"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "The init script is a bit of JavaScript or CoffeeScript run at startup. You can use it to quickly change the behaviour of Atom."
+    'open-init-script': "Open your Init Script"
+    detail2: "Uncomment some of the examples or try out your own." 
+    note:
+      text1: "Next time:"
+      text2: " You can open your init script from Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: "Add a "
+      text2: "Snippet"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom snippets allow you to enter a simple prefix in the editor and hit tab to expand the prefix into a larger code block with templated values."
+    'open-snippet': "Open your Snippets"
+    detail2: "In your snippets file, type <code>snip</code> then hit <code>tab</code>. The <code>snip</code> snippet will expand to create a snippet!"
+    note:
+      text1: "Next time:"
+      text2: " You can open your snippets in Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: "Learn "
+      text2: "Keyboard Shortcuts"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "If you only remember one keyboard shortcut make it "
+      text2: ". This keystroke toggles the command palette, which lists every Atom command.
+              It's a good way to learn more shortcuts. Yes, you can try it now!"
+      text3: "If you want to use these guides again use the command palette "
+      text4: " and search for "
+      text5: "Welcome"
+      text6: "."
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/fr/welcome.cson
+++ b/def/fr/welcome.cson
@@ -1,29 +1,24 @@
 Welcome:
   tabTitle: "Bienvenue"
-  subtitle: {
+  subtitle:
     text1: "Un éditeur de texte ultra-configurable pour le 21"
     superscript: "e"
     text2: " siècle"
-  }
-  help: {
+  help:
     forHelpVisit: "Besoin d'aide ? Visitez"
-    atomDocs: {
+    atomDocs:
       text1: "les "
       link: "Atom docs"
       text2: " comportant des guides et les références de l'API."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomForum: {
+    atomForum:
       text1: "Le forum d'Atom sur "
       link: "discuss.atom.io"
       text2: ""   # optional
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomOrg: {
+    atomOrg:
       text1: "Le "
       link: "Atom org"
       text2: ". C'est là que se trouvent tous les packages Atom créés sur GitHub."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-  }
   showWelcomeGuide: "Afficher le guide de bienvenue à l'ouverture d'Atom"

--- a/def/he/consent.cson
+++ b/def/he/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "Telemetry Consent"
+  desc:
+    text1: "Help improve Atom by sending your anonymous "
+    text2: "usage data"
+    text3: " to the Atom team. The resulting data plays a key role in deciding what we focus on next."
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "Yes, send my usage data"
+    notes:
+      text1: "Including exception and crash reports. See the "
+      text2: "atom/metrics package"
+      text3: " for more details."
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "No, do not send my usage data"
+    notes: "Note: We only register anonymously that you opted-out."
+  with: " with "
+  by: " by "

--- a/def/he/guide.cson
+++ b/def/he/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "Welcome Guide"
+  subTitle: "Get to know Atom!"
+  project:
+    title:
+      text1: "Open a "
+      text2: "Project"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "In Atom you can open individual files or a whole folder as a project. 
+             Opening a folder will add a tree view to the editor where you can browse all the files."
+    'open-project': "Open a Project"
+    note:
+      text1: "Next time:"
+      text2: " You can also open projects from the menu, keyboard shortcut or by dragging a folder onto the Atom dock icon."
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: "Version control with "
+      text2: "Git and GitHub"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Track changes to your code as you work. Branch, commit, push, and pull without leaving the comfort of your editor.
+             Collaborate with other developers on GitHub."
+    'open-git': "Open the Git panel"
+    'open-github': "Open the GitHub panel"
+    note:
+      text1: "Next time:"
+      text2: " You can toggle the Git tab by clicking on the "
+      text3: " button in your status bar."
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: "Collaborate in real time with "
+      text2: "Teletype"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Share your workspace with team members and collaborate on code in real time."
+    'install-teletype': "Install Teletype for Atom"
+  packages:
+    title:
+      text1: "Install a "
+      text2: "Package"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "One of the best things about Atom is the package ecosystem.
+             Installing packages adds new features and functionality you can use to make the editor suit your needs. Let's install one."
+    'install-package': "Open Installer"
+    note:
+      text1: "Next time:"
+      text2: " You can install new packages from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: "Choose a "
+      text2: "Theme"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom comes with preinstalled themes. Let's try a few."
+    'open-theme': "Open the theme picker"
+    detail2: "You can also install themes created by the Atom community. 
+              To install new themes, click on \"+ Install\" and switch the toggle to \"themes\"."
+    note:
+      text1: "Next time:"
+      text2: " You can switch themes from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: "Customize the "
+      text2: "Styling"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "You can customize almost anything by adding your own CSS/LESS." 
+    'open-stylesheet': "Open your Stylesheet"
+    detail2: "Now uncomment some of the examples or try your own" 
+    note:
+      text1: "Next time:"
+      text2: " You can open your stylesheet from Menu File."
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: "Hack on the "
+      text2: "Init Script"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "The init script is a bit of JavaScript or CoffeeScript run at startup. You can use it to quickly change the behaviour of Atom."
+    'open-init-script': "Open your Init Script"
+    detail2: "Uncomment some of the examples or try out your own." 
+    note:
+      text1: "Next time:"
+      text2: " You can open your init script from Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: "Add a "
+      text2: "Snippet"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom snippets allow you to enter a simple prefix in the editor and hit tab to expand the prefix into a larger code block with templated values."
+    'open-snippet': "Open your Snippets"
+    detail2: "In your snippets file, type <code>snip</code> then hit <code>tab</code>. The <code>snip</code> snippet will expand to create a snippet!"
+    note:
+      text1: "Next time:"
+      text2: " You can open your snippets in Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: "Learn "
+      text2: "Keyboard Shortcuts"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "If you only remember one keyboard shortcut make it "
+      text2: ". This keystroke toggles the command palette, which lists every Atom command.
+              It's a good way to learn more shortcuts. Yes, you can try it now!"
+      text3: "If you want to use these guides again use the command palette "
+      text4: " and search for "
+      text5: "Welcome"
+      text6: "."
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/he/welcome.cson
+++ b/def/he/welcome.cson
@@ -1,29 +1,24 @@
 Welcome:
   tabTitle: "ברוך הבא!"
-  subtitle: {
+  subtitle:
     text1: "עורך טקסט עדכני עבור המאה "
     superscript: ""
     text2: "העשרים ואחת"
-  }
-  help: {
+  help:
     forHelpVisit: "לקבלת עזרה, בבקשה בקר"
-    atomDocs: {
+    atomDocs:
       text1: "את "
       link: "הדוקומנטציה הרשמית"
       text2: " בשביל מדריכים והפנייה לממשק תכנות היישומים"
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomForum: {
+    atomForum:
       text1: ""
       link: "discuss.atom.io"
       text2: "את הפורום של אטום ב"
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomOrg: {
+    atomOrg:
       text1: "את "
       link: "אטום אורג"
       text2: ". זהו המקום שבו תמצא את כל התוספים הרשמיים של אטום"
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-  }
   showWelcomeGuide: "הצג את המדריך הזה בכל הפעלה חדשה של אטום"

--- a/def/hi/consent.cson
+++ b/def/hi/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "Telemetry Consent"
+  desc:
+    text1: "Help improve Atom by sending your anonymous "
+    text2: "usage data"
+    text3: " to the Atom team. The resulting data plays a key role in deciding what we focus on next."
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "Yes, send my usage data"
+    notes:
+      text1: "Including exception and crash reports. See the "
+      text2: "atom/metrics package"
+      text3: " for more details."
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "No, do not send my usage data"
+    notes: "Note: We only register anonymously that you opted-out."
+  with: " with "
+  by: " by "

--- a/def/hi/guide.cson
+++ b/def/hi/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "Welcome Guide"
+  subTitle: "Get to know Atom!"
+  project:
+    title:
+      text1: "Open a "
+      text2: "Project"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "In Atom you can open individual files or a whole folder as a project. 
+             Opening a folder will add a tree view to the editor where you can browse all the files."
+    'open-project': "Open a Project"
+    note:
+      text1: "Next time:"
+      text2: " You can also open projects from the menu, keyboard shortcut or by dragging a folder onto the Atom dock icon."
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: "Version control with "
+      text2: "Git and GitHub"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Track changes to your code as you work. Branch, commit, push, and pull without leaving the comfort of your editor.
+             Collaborate with other developers on GitHub."
+    'open-git': "Open the Git panel"
+    'open-github': "Open the GitHub panel"
+    note:
+      text1: "Next time:"
+      text2: " You can toggle the Git tab by clicking on the "
+      text3: " button in your status bar."
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: "Collaborate in real time with "
+      text2: "Teletype"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Share your workspace with team members and collaborate on code in real time."
+    'install-teletype': "Install Teletype for Atom"
+  packages:
+    title:
+      text1: "Install a "
+      text2: "Package"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "One of the best things about Atom is the package ecosystem.
+             Installing packages adds new features and functionality you can use to make the editor suit your needs. Let's install one."
+    'install-package': "Open Installer"
+    note:
+      text1: "Next time:"
+      text2: " You can install new packages from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: "Choose a "
+      text2: "Theme"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom comes with preinstalled themes. Let's try a few."
+    'open-theme': "Open the theme picker"
+    detail2: "You can also install themes created by the Atom community. 
+              To install new themes, click on \"+ Install\" and switch the toggle to \"themes\"."
+    note:
+      text1: "Next time:"
+      text2: " You can switch themes from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: "Customize the "
+      text2: "Styling"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "You can customize almost anything by adding your own CSS/LESS." 
+    'open-stylesheet': "Open your Stylesheet"
+    detail2: "Now uncomment some of the examples or try your own" 
+    note:
+      text1: "Next time:"
+      text2: " You can open your stylesheet from Menu File."
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: "Hack on the "
+      text2: "Init Script"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "The init script is a bit of JavaScript or CoffeeScript run at startup. You can use it to quickly change the behaviour of Atom."
+    'open-init-script': "Open your Init Script"
+    detail2: "Uncomment some of the examples or try out your own." 
+    note:
+      text1: "Next time:"
+      text2: " You can open your init script from Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: "Add a "
+      text2: "Snippet"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom snippets allow you to enter a simple prefix in the editor and hit tab to expand the prefix into a larger code block with templated values."
+    'open-snippet': "Open your Snippets"
+    detail2: "In your snippets file, type <code>snip</code> then hit <code>tab</code>. The <code>snip</code> snippet will expand to create a snippet!"
+    note:
+      text1: "Next time:"
+      text2: " You can open your snippets in Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: "Learn "
+      text2: "Keyboard Shortcuts"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "If you only remember one keyboard shortcut make it "
+      text2: ". This keystroke toggles the command palette, which lists every Atom command.
+              It's a good way to learn more shortcuts. Yes, you can try it now!"
+      text3: "If you want to use these guides again use the command palette "
+      text4: " and search for "
+      text5: "Welcome"
+      text6: "."
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/hi/welcome.cson
+++ b/def/hi/welcome.cson
@@ -1,29 +1,24 @@
 Welcome:
   tabTitle: "नमसते"
-  subtitle: {
+  subtitle:
     text1: "२१ वी सदी के लिए एक हैक करने योग्य पाठ संपादक"
     superscript: ""
     text2: " "
-  }
-  help: {
+  help:
     forHelpVisit: "मदद के लिए, कृपया देखें"
-    atomDocs: {
+    atomDocs:
       text1: ""
       link: "Atom docs"
       text2: "गाइड तथा API संदर्भ के लिये "
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomForum: {
+    atomForum:
       text1: "एटोम मंच पर "
       link: "discuss.atom.io"
       text2: ""   # optional
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomOrg: {
+    atomOrg:
       text1: ""
       link: "Atom org"
       text2: ".यह वह जगह है जहाँ सभी GitHub निर्मित एटम पैकेज मिल सकते हैं "
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-  }
   showWelcomeGuide: "एटम खोलते समय ये वेलकम गाइड दिखाएं"

--- a/def/hu/consent.cson
+++ b/def/hu/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "Telemetry Consent"
+  desc:
+    text1: "Help improve Atom by sending your anonymous "
+    text2: "usage data"
+    text3: " to the Atom team. The resulting data plays a key role in deciding what we focus on next."
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "Yes, send my usage data"
+    notes:
+      text1: "Including exception and crash reports. See the "
+      text2: "atom/metrics package"
+      text3: " for more details."
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "No, do not send my usage data"
+    notes: "Note: We only register anonymously that you opted-out."
+  with: " with "
+  by: " by "

--- a/def/hu/guide.cson
+++ b/def/hu/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "Welcome Guide"
+  subTitle: "Get to know Atom!"
+  project:
+    title:
+      text1: "Open a "
+      text2: "Project"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "In Atom you can open individual files or a whole folder as a project. 
+             Opening a folder will add a tree view to the editor where you can browse all the files."
+    'open-project': "Open a Project"
+    note:
+      text1: "Next time:"
+      text2: " You can also open projects from the menu, keyboard shortcut or by dragging a folder onto the Atom dock icon."
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: "Version control with "
+      text2: "Git and GitHub"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Track changes to your code as you work. Branch, commit, push, and pull without leaving the comfort of your editor.
+             Collaborate with other developers on GitHub."
+    'open-git': "Open the Git panel"
+    'open-github': "Open the GitHub panel"
+    note:
+      text1: "Next time:"
+      text2: " You can toggle the Git tab by clicking on the "
+      text3: " button in your status bar."
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: "Collaborate in real time with "
+      text2: "Teletype"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Share your workspace with team members and collaborate on code in real time."
+    'install-teletype': "Install Teletype for Atom"
+  packages:
+    title:
+      text1: "Install a "
+      text2: "Package"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "One of the best things about Atom is the package ecosystem.
+             Installing packages adds new features and functionality you can use to make the editor suit your needs. Let's install one."
+    'install-package': "Open Installer"
+    note:
+      text1: "Next time:"
+      text2: " You can install new packages from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: "Choose a "
+      text2: "Theme"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom comes with preinstalled themes. Let's try a few."
+    'open-theme': "Open the theme picker"
+    detail2: "You can also install themes created by the Atom community. 
+              To install new themes, click on \"+ Install\" and switch the toggle to \"themes\"."
+    note:
+      text1: "Next time:"
+      text2: " You can switch themes from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: "Customize the "
+      text2: "Styling"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "You can customize almost anything by adding your own CSS/LESS." 
+    'open-stylesheet': "Open your Stylesheet"
+    detail2: "Now uncomment some of the examples or try your own" 
+    note:
+      text1: "Next time:"
+      text2: " You can open your stylesheet from Menu File."
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: "Hack on the "
+      text2: "Init Script"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "The init script is a bit of JavaScript or CoffeeScript run at startup. You can use it to quickly change the behaviour of Atom."
+    'open-init-script': "Open your Init Script"
+    detail2: "Uncomment some of the examples or try out your own." 
+    note:
+      text1: "Next time:"
+      text2: " You can open your init script from Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: "Add a "
+      text2: "Snippet"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom snippets allow you to enter a simple prefix in the editor and hit tab to expand the prefix into a larger code block with templated values."
+    'open-snippet': "Open your Snippets"
+    detail2: "In your snippets file, type <code>snip</code> then hit <code>tab</code>. The <code>snip</code> snippet will expand to create a snippet!"
+    note:
+      text1: "Next time:"
+      text2: " You can open your snippets in Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: "Learn "
+      text2: "Keyboard Shortcuts"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "If you only remember one keyboard shortcut make it "
+      text2: ". This keystroke toggles the command palette, which lists every Atom command.
+              It's a good way to learn more shortcuts. Yes, you can try it now!"
+      text3: "If you want to use these guides again use the command palette "
+      text4: " and search for "
+      text5: "Welcome"
+      text6: "."
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/hu/welcome.cson
+++ b/def/hu/welcome.cson
@@ -1,29 +1,24 @@
 Welcome:
   tabTitle: "Üdvözlet!"
-  subtitle: {
+  subtitle:
     text1: "Testreszabható szövegszerkesztő a 21"
     superscript: "."
     text2: " századnak"
-  }
-  help: {
+  help:
     forHelpVisit: "Hasznos webhelyek (angolul): "
-    atomDocs: {
+    atomDocs:
       text1: "Az "
       link: "Atom "
       text2: " dokumentációs oldala, a teljes API referenciával."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomForum: {
+    atomForum:
       text1: "Az Atom "
       link: "felhasználói fóruma"
       text2: ""   # optional
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomOrg: {
+    atomOrg:
       text1: "Az Atom "
       link: "GitHub oldala"
       text2: ", ahol megtalálható az Atom-hoz elérhető összes csomag."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-  }
   showWelcomeGuide: "Az Atom megnyitásakor mindig mutassa ezt az üdvözlő-lapot"

--- a/def/it/consent.cson
+++ b/def/it/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "Telemetry Consent"
+  desc:
+    text1: "Help improve Atom by sending your anonymous "
+    text2: "usage data"
+    text3: " to the Atom team. The resulting data plays a key role in deciding what we focus on next."
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "Yes, send my usage data"
+    notes:
+      text1: "Including exception and crash reports. See the "
+      text2: "atom/metrics package"
+      text3: " for more details."
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "No, do not send my usage data"
+    notes: "Note: We only register anonymously that you opted-out."
+  with: " with "
+  by: " by "

--- a/def/it/guide.cson
+++ b/def/it/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "Welcome Guide"
+  subTitle: "Get to know Atom!"
+  project:
+    title:
+      text1: "Open a "
+      text2: "Project"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "In Atom you can open individual files or a whole folder as a project. 
+             Opening a folder will add a tree view to the editor where you can browse all the files."
+    'open-project': "Open a Project"
+    note:
+      text1: "Next time:"
+      text2: " You can also open projects from the menu, keyboard shortcut or by dragging a folder onto the Atom dock icon."
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: "Version control with "
+      text2: "Git and GitHub"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Track changes to your code as you work. Branch, commit, push, and pull without leaving the comfort of your editor.
+             Collaborate with other developers on GitHub."
+    'open-git': "Open the Git panel"
+    'open-github': "Open the GitHub panel"
+    note:
+      text1: "Next time:"
+      text2: " You can toggle the Git tab by clicking on the "
+      text3: " button in your status bar."
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: "Collaborate in real time with "
+      text2: "Teletype"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Share your workspace with team members and collaborate on code in real time."
+    'install-teletype': "Install Teletype for Atom"
+  packages:
+    title:
+      text1: "Install a "
+      text2: "Package"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "One of the best things about Atom is the package ecosystem.
+             Installing packages adds new features and functionality you can use to make the editor suit your needs. Let's install one."
+    'install-package': "Open Installer"
+    note:
+      text1: "Next time:"
+      text2: " You can install new packages from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: "Choose a "
+      text2: "Theme"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom comes with preinstalled themes. Let's try a few."
+    'open-theme': "Open the theme picker"
+    detail2: "You can also install themes created by the Atom community. 
+              To install new themes, click on \"+ Install\" and switch the toggle to \"themes\"."
+    note:
+      text1: "Next time:"
+      text2: " You can switch themes from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: "Customize the "
+      text2: "Styling"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "You can customize almost anything by adding your own CSS/LESS." 
+    'open-stylesheet': "Open your Stylesheet"
+    detail2: "Now uncomment some of the examples or try your own" 
+    note:
+      text1: "Next time:"
+      text2: " You can open your stylesheet from Menu File."
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: "Hack on the "
+      text2: "Init Script"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "The init script is a bit of JavaScript or CoffeeScript run at startup. You can use it to quickly change the behaviour of Atom."
+    'open-init-script': "Open your Init Script"
+    detail2: "Uncomment some of the examples or try out your own." 
+    note:
+      text1: "Next time:"
+      text2: " You can open your init script from Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: "Add a "
+      text2: "Snippet"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom snippets allow you to enter a simple prefix in the editor and hit tab to expand the prefix into a larger code block with templated values."
+    'open-snippet': "Open your Snippets"
+    detail2: "In your snippets file, type <code>snip</code> then hit <code>tab</code>. The <code>snip</code> snippet will expand to create a snippet!"
+    note:
+      text1: "Next time:"
+      text2: " You can open your snippets in Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: "Learn "
+      text2: "Keyboard Shortcuts"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "If you only remember one keyboard shortcut make it "
+      text2: ". This keystroke toggles the command palette, which lists every Atom command.
+              It's a good way to learn more shortcuts. Yes, you can try it now!"
+      text3: "If you want to use these guides again use the command palette "
+      text4: " and search for "
+      text5: "Welcome"
+      text6: "."
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/it/welcome.cson
+++ b/def/it/welcome.cson
@@ -1,29 +1,24 @@
 Welcome:
   tabTitle: "Benvenuto"
-  subtitle: {
+  subtitle:
     text1: "Un editor di testo hackerabile per il 21"
     superscript: "o"
     text2: " secolo"
-  }
-  help: {
+  help:
     forHelpVisit: "Per ricevere supporto, visita"
-    atomDocs: {
+    atomDocs:
       text1: "La "
       link: "documentazione di Atom"
       text2: " per le Guide e la consultazione delle API."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomForum: {
+    atomForum:
       text1: "Il forum di Atom presso "
       link: "'discuss.atom.io'"
       text2: "."   # optional
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomOrg: {
+    atomOrg:
       text1: "Il sito "
       link: "'Atom.org'"
       text2: ", dove si trovano tutti i pacchetti per Atom creati su GitHub."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-  }
   showWelcomeGuide: "Mostra la Guida di Benvenuto all'avvio di Atom"

--- a/def/ja/consent.cson
+++ b/def/ja/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "使用状況データの送信"
+  desc:
+    text1: "匿名の "
+    text2: "使用状況データ"
+    text3: " を Atomチームに送信して、Atom の改善にご協力ください。送信されたデータは、今後の機能強化を決定する上で重要な役割を果たします。"
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "はい、使用状況データ送信します"
+    notes:
+      text1: "例外およびクラッシュレポートを含みます。 詳細については、"
+      text2: "atomic/metrics パッケージ"
+      text3: " を参照してください。"
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "いいえ、送信しないでください"
+    notes: "注: オプトアウト (送信拒否) したことのみを匿名で登録します。"
+  with: " に "
+  by: " を込めて "

--- a/def/ja/guide.cson
+++ b/def/ja/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "ウエルカム ガイド"
+  subTitle: "Atom を知ろう！"
+  project:
+    title:
+      text1: ""
+      text2: "プロジェクト"
+      text3: "を開く"        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom では、個々のファイルまたはフォルダー全体をプロジェクトとして開くことができます。 
+             フォルダを開くと、エディターにツリービューが追加され、すべてのファイルを閲覧することができます。"
+    'open-project': "プロジェクトを開く"
+    note:
+      text1: "次回ヒント:"
+      text2: " メニューやキーボードショートカットからプロジェクトを開くこともできますし、Atomのドックアイコンにフォルダをドラッグして開くこともできます。"
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: ""
+      text2: "Git と GitHub"
+      text3: " によるバージョン管理"        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "作業中にコードへの変更を追跡できます。 エディターにいながら、ブランチ、コミット、プッシュ、およびプルを行うことができます。
+             GitHub で他の開発者と共同作業を行います。"
+    'open-git': "Git パネルを開く"
+    'open-github': "GitHub パネルを開く"
+    note:
+      text1: "次回ヒント:"
+      text2: " ステータスバーの "
+      text3: " ボタンをクリックすると、Git タブを切り替えることができます。"
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: ""
+      text2: "テレタイプ"
+      text3: "でリアルタイムの共同作業"        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "ワークスペースをチームメンバーと共有し、リアルタイムでコードの共同作業をすることができます。"
+    'install-teletype': "Teletype for Atom のインストール"
+  packages:
+    title:
+      text1: ""
+      text2: "パッケージ"
+      text3: "のインストール"        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom の優れた点のひとつに、パッケージのエコシステムがあります。
+             パッケージをインストールすると、新しい機能が追加され、自分のニーズに合ったエディタにすることができます。一つインストールしてみましょう。"
+    'install-package': "インストーラーを開く"
+    note:
+      text1: "次回ヒント:"
+      text2: " 設定から新しいパッケージをインストールできます。"
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: ""
+      text2: "テーマ"
+      text3: "の選択"        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom にはテーマがプリインストールされています。いくつか試してみましょう。"
+    'open-theme': "[テーマの選択] を開く"
+    detail2: "また、Atom コミュニティが作成したテーマをインストールすることもできます。 
+              新しいテーマをインストールするには、[インストール] をクリックして、トグルを [テーマ] に切り替えてください。"
+    note:
+      text1: "次回ヒント:"
+      text2: " 設定からテーマを切り替えることができます。"
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: ""
+      text2: "スタイル指定"
+      text3: "のカスタマイズ"        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "独自の CSS/LESS を追加することで、ほとんどのカスタマイズが可能です。" 
+    'open-stylesheet': "スタイルシートを開く"
+    detail2: "ここで、いくつかの例のコメントを外すか、独自の例を試してください。" 
+    note:
+      text1: "次回ヒント:"
+      text2: " [ファイル] メニューからスタイルシートを開くことができます。"
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: ""
+      text2: "初期化スクリプト"
+      text3: "の設定"        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "初期化スクリプトは、起動時に実行される JavaScript または CoffeeScript コードです。 これを使用して、Atom の動作をすばやく変更できます。"
+    'open-init-script': "初期化スクリプトを開く"
+    detail2: "いくつかの例のコメントを外すか、独自の例を試してください。" 
+    note:
+      text1: "次回ヒント:"
+      text2: " [ファイル] メニューから初期化スクリプトを開くことができます。"
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: ""
+      text2: "スニペット"
+      text3: "の追加"        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom スニペットを利用すると、エディタに簡単なプレフィックスを入力してタブを押すことにより、そのプレフィックスがテンプレート化された値を持つより大きなコードブロックに展開されます。"
+    'open-snippet': "スニペット設定を開く"
+    detail2: "スニペットファイルに <code>snip</code> と入力し、<code>tab</code> を押します。 <code>snip</code> スニペットが展開され、スニペットが作成されます。"
+    note:
+      text1: "次回ヒント:"
+      text2: " [ファイル] メニューからスニペットを開くことができます。"
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: ""
+      text2: "キーボード ショートカット"
+      text3: "を学ぶ"        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "キーボードショートカットを1つだけ覚えるとしたら、まず "
+      text2: " にしましょう。このキーストロークは、Atom のすべてのコマンドを一覧表示するコマンドパレットに切り替えます。
+              より多くのショートカットを学ぶことができます。では、今すぐ試してみましょう。"
+      text3: "このガイドを再表示したい場合は、コマンドパレット "
+      text4: " を使用して、"
+      text5: "Welcome"
+      text6: " を検索してください。"
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/ja/welcome.cson
+++ b/def/ja/welcome.cson
@@ -1,29 +1,24 @@
 Welcome:
   tabTitle: "ようこそ"
-  subtitle: {
+  subtitle:
     text1: "21世紀のためのハック可能なテキストエディタ"
     superscript: ""
     text2: ""
-  }
-  help: {
+  help:
     forHelpVisit: "ヘルプについては以下をご覧ください。"
-    atomDocs: {
+    atomDocs:
       text1: "使い方及び API リファレンスは "
       link: "Atom docs"
       text2: " へ。"
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomForum: {
+    atomForum:
       text1: "Atom のフォーラムは "
       link: "discuss.atom.io"
       text2: " へ。"   # optional
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomOrg: {
+    atomOrg:
       text1: "GitHub 上で作成された全ての Atom パッケージを見つけるには "
       link: "Atom org"
       text2: " へ。"
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-  }
   showWelcomeGuide: "Atom を開いた時にウェルカムガイドを表示する"

--- a/def/kn/consent.cson
+++ b/def/kn/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "Telemetry Consent"
+  desc:
+    text1: "Help improve Atom by sending your anonymous "
+    text2: "usage data"
+    text3: " to the Atom team. The resulting data plays a key role in deciding what we focus on next."
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "Yes, send my usage data"
+    notes:
+      text1: "Including exception and crash reports. See the "
+      text2: "atom/metrics package"
+      text3: " for more details."
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "No, do not send my usage data"
+    notes: "Note: We only register anonymously that you opted-out."
+  with: " with "
+  by: " by "

--- a/def/kn/guide.cson
+++ b/def/kn/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "Welcome Guide"
+  subTitle: "Get to know Atom!"
+  project:
+    title:
+      text1: "Open a "
+      text2: "Project"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "In Atom you can open individual files or a whole folder as a project. 
+             Opening a folder will add a tree view to the editor where you can browse all the files."
+    'open-project': "Open a Project"
+    note:
+      text1: "Next time:"
+      text2: " You can also open projects from the menu, keyboard shortcut or by dragging a folder onto the Atom dock icon."
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: "Version control with "
+      text2: "Git and GitHub"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Track changes to your code as you work. Branch, commit, push, and pull without leaving the comfort of your editor.
+             Collaborate with other developers on GitHub."
+    'open-git': "Open the Git panel"
+    'open-github': "Open the GitHub panel"
+    note:
+      text1: "Next time:"
+      text2: " You can toggle the Git tab by clicking on the "
+      text3: " button in your status bar."
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: "Collaborate in real time with "
+      text2: "Teletype"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Share your workspace with team members and collaborate on code in real time."
+    'install-teletype': "Install Teletype for Atom"
+  packages:
+    title:
+      text1: "Install a "
+      text2: "Package"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "One of the best things about Atom is the package ecosystem.
+             Installing packages adds new features and functionality you can use to make the editor suit your needs. Let's install one."
+    'install-package': "Open Installer"
+    note:
+      text1: "Next time:"
+      text2: " You can install new packages from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: "Choose a "
+      text2: "Theme"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom comes with preinstalled themes. Let's try a few."
+    'open-theme': "Open the theme picker"
+    detail2: "You can also install themes created by the Atom community. 
+              To install new themes, click on \"+ Install\" and switch the toggle to \"themes\"."
+    note:
+      text1: "Next time:"
+      text2: " You can switch themes from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: "Customize the "
+      text2: "Styling"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "You can customize almost anything by adding your own CSS/LESS." 
+    'open-stylesheet': "Open your Stylesheet"
+    detail2: "Now uncomment some of the examples or try your own" 
+    note:
+      text1: "Next time:"
+      text2: " You can open your stylesheet from Menu File."
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: "Hack on the "
+      text2: "Init Script"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "The init script is a bit of JavaScript or CoffeeScript run at startup. You can use it to quickly change the behaviour of Atom."
+    'open-init-script': "Open your Init Script"
+    detail2: "Uncomment some of the examples or try out your own." 
+    note:
+      text1: "Next time:"
+      text2: " You can open your init script from Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: "Add a "
+      text2: "Snippet"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom snippets allow you to enter a simple prefix in the editor and hit tab to expand the prefix into a larger code block with templated values."
+    'open-snippet': "Open your Snippets"
+    detail2: "In your snippets file, type <code>snip</code> then hit <code>tab</code>. The <code>snip</code> snippet will expand to create a snippet!"
+    note:
+      text1: "Next time:"
+      text2: " You can open your snippets in Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: "Learn "
+      text2: "Keyboard Shortcuts"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "If you only remember one keyboard shortcut make it "
+      text2: ". This keystroke toggles the command palette, which lists every Atom command.
+              It's a good way to learn more shortcuts. Yes, you can try it now!"
+      text3: "If you want to use these guides again use the command palette "
+      text4: " and search for "
+      text5: "Welcome"
+      text6: "."
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/kn/welcome.cson
+++ b/def/kn/welcome.cson
@@ -1,29 +1,24 @@
 Welcome:
   tabTitle: "ಸ್ವಾಗತ"
-  subtitle: {
+  subtitle:
     text1: "21 ನೇ ಶತಮಾನ "
     superscript: " ಪಠ್ಯ"
     text2: " ಸಂಪಾದಕ"
-  }
-  help: {
+  help:
     forHelpVisit: "ಸಹಾಯಕ್ಕಾಗಿ, ದಯವಿಟ್ಟು ಭೇಟಿ ನೀಡಿ"
-    atomDocs: {
+    atomDocs:
       text1: " "
       link: "ಅಣು(Atom) ದಾಖಲೆ"
       text2: " ಮಾರ್ಗದರ್ಶಿಗಳು ಮತ್ತು API ಉಲ್ಲೇಖಕ್ಕಾಗಿ."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomForum: {
+    atomForum:
       text1: "ಅಣು(Atom) ವೇದಿಕೆ"
       link: "discuss.atom.io"
       text2: ""   # optional
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomOrg: {
+    atomOrg:
       text1: " "
       link: "ಅಣು(Atom) ಸಂಸ್ಥೆ"
       text2: ". GitHub- ರಚಿಸಿದ ಎಲ್ಲಾ ಆಯ್ಟಮ್ ಪ್ಯಾಕೇಜ್‌ಗಳನ್ನು ಇಲ್ಲಿ ಕಾಣಬಹುದು."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-  }
   showWelcomeGuide: "ಅಣು(Atom) ತೆರೆಯುವಾಗ ಸ್ವಾಗತ ಮಾರ್ಗದರ್ಶಿ ತೋರಿಸಿ"

--- a/def/ko/consent.cson
+++ b/def/ko/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "Telemetry Consent"
+  desc:
+    text1: "Help improve Atom by sending your anonymous "
+    text2: "usage data"
+    text3: " to the Atom team. The resulting data plays a key role in deciding what we focus on next."
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "Yes, send my usage data"
+    notes:
+      text1: "Including exception and crash reports. See the "
+      text2: "atom/metrics package"
+      text3: " for more details."
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "No, do not send my usage data"
+    notes: "Note: We only register anonymously that you opted-out."
+  with: " with "
+  by: " by "

--- a/def/ko/guide.cson
+++ b/def/ko/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "Welcome Guide"
+  subTitle: "Get to know Atom!"
+  project:
+    title:
+      text1: "Open a "
+      text2: "Project"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "In Atom you can open individual files or a whole folder as a project. 
+             Opening a folder will add a tree view to the editor where you can browse all the files."
+    'open-project': "Open a Project"
+    note:
+      text1: "Next time:"
+      text2: " You can also open projects from the menu, keyboard shortcut or by dragging a folder onto the Atom dock icon."
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: "Version control with "
+      text2: "Git and GitHub"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Track changes to your code as you work. Branch, commit, push, and pull without leaving the comfort of your editor.
+             Collaborate with other developers on GitHub."
+    'open-git': "Open the Git panel"
+    'open-github': "Open the GitHub panel"
+    note:
+      text1: "Next time:"
+      text2: " You can toggle the Git tab by clicking on the "
+      text3: " button in your status bar."
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: "Collaborate in real time with "
+      text2: "Teletype"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Share your workspace with team members and collaborate on code in real time."
+    'install-teletype': "Install Teletype for Atom"
+  packages:
+    title:
+      text1: "Install a "
+      text2: "Package"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "One of the best things about Atom is the package ecosystem.
+             Installing packages adds new features and functionality you can use to make the editor suit your needs. Let's install one."
+    'install-package': "Open Installer"
+    note:
+      text1: "Next time:"
+      text2: " You can install new packages from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: "Choose a "
+      text2: "Theme"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom comes with preinstalled themes. Let's try a few."
+    'open-theme': "Open the theme picker"
+    detail2: "You can also install themes created by the Atom community. 
+              To install new themes, click on \"+ Install\" and switch the toggle to \"themes\"."
+    note:
+      text1: "Next time:"
+      text2: " You can switch themes from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: "Customize the "
+      text2: "Styling"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "You can customize almost anything by adding your own CSS/LESS." 
+    'open-stylesheet': "Open your Stylesheet"
+    detail2: "Now uncomment some of the examples or try your own" 
+    note:
+      text1: "Next time:"
+      text2: " You can open your stylesheet from Menu File."
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: "Hack on the "
+      text2: "Init Script"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "The init script is a bit of JavaScript or CoffeeScript run at startup. You can use it to quickly change the behaviour of Atom."
+    'open-init-script': "Open your Init Script"
+    detail2: "Uncomment some of the examples or try out your own." 
+    note:
+      text1: "Next time:"
+      text2: " You can open your init script from Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: "Add a "
+      text2: "Snippet"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom snippets allow you to enter a simple prefix in the editor and hit tab to expand the prefix into a larger code block with templated values."
+    'open-snippet': "Open your Snippets"
+    detail2: "In your snippets file, type <code>snip</code> then hit <code>tab</code>. The <code>snip</code> snippet will expand to create a snippet!"
+    note:
+      text1: "Next time:"
+      text2: " You can open your snippets in Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: "Learn "
+      text2: "Keyboard Shortcuts"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "If you only remember one keyboard shortcut make it "
+      text2: ". This keystroke toggles the command palette, which lists every Atom command.
+              It's a good way to learn more shortcuts. Yes, you can try it now!"
+      text3: "If you want to use these guides again use the command palette "
+      text4: " and search for "
+      text5: "Welcome"
+      text6: "."
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/ko/welcome.cson
+++ b/def/ko/welcome.cson
@@ -1,29 +1,24 @@
 Welcome:
   tabTitle: "환영합니다"
-  subtitle: {
+  subtitle:
     text1: "해킹할 수 있는 21세기 텍스트 편집기"
     superscript: ""
     text2: " "
-  }
-  help: {
+  help:
     forHelpVisit: "도움이 필요하시다면, 다음을 참고해 주세요."
-    atomDocs: {
+    atomDocs:
       text1: "설명서 또는 API 참고 문서는 "
       link: "Atom docs"
       text2: " 에서 확인해주세요."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomForum: {
+    atomForum:
       text1: "Atom 포험은 "
       link: "discuss.atom.io"
       text2: " 에서 확인해주세요."   # optional
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomOrg: {
+    atomOrg:
       text1: "GitHub에 생성된 모든 Atom의 패키지를 찾으시려면 "
       link: "Atom org"
       text2: " 에서 확인해주세요."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-  }
   showWelcomeGuide: "Atom 시작 시, 환영 가이드 보기"

--- a/def/ms/consent.cson
+++ b/def/ms/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "Telemetry Consent"
+  desc:
+    text1: "Help improve Atom by sending your anonymous "
+    text2: "usage data"
+    text3: " to the Atom team. The resulting data plays a key role in deciding what we focus on next."
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "Yes, send my usage data"
+    notes:
+      text1: "Including exception and crash reports. See the "
+      text2: "atom/metrics package"
+      text3: " for more details."
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "No, do not send my usage data"
+    notes: "Note: We only register anonymously that you opted-out."
+  with: " with "
+  by: " by "

--- a/def/ms/guide.cson
+++ b/def/ms/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "Welcome Guide"
+  subTitle: "Get to know Atom!"
+  project:
+    title:
+      text1: "Open a "
+      text2: "Project"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "In Atom you can open individual files or a whole folder as a project. 
+             Opening a folder will add a tree view to the editor where you can browse all the files."
+    'open-project': "Open a Project"
+    note:
+      text1: "Next time:"
+      text2: " You can also open projects from the menu, keyboard shortcut or by dragging a folder onto the Atom dock icon."
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: "Version control with "
+      text2: "Git and GitHub"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Track changes to your code as you work. Branch, commit, push, and pull without leaving the comfort of your editor.
+             Collaborate with other developers on GitHub."
+    'open-git': "Open the Git panel"
+    'open-github': "Open the GitHub panel"
+    note:
+      text1: "Next time:"
+      text2: " You can toggle the Git tab by clicking on the "
+      text3: " button in your status bar."
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: "Collaborate in real time with "
+      text2: "Teletype"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Share your workspace with team members and collaborate on code in real time."
+    'install-teletype': "Install Teletype for Atom"
+  packages:
+    title:
+      text1: "Install a "
+      text2: "Package"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "One of the best things about Atom is the package ecosystem.
+             Installing packages adds new features and functionality you can use to make the editor suit your needs. Let's install one."
+    'install-package': "Open Installer"
+    note:
+      text1: "Next time:"
+      text2: " You can install new packages from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: "Choose a "
+      text2: "Theme"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom comes with preinstalled themes. Let's try a few."
+    'open-theme': "Open the theme picker"
+    detail2: "You can also install themes created by the Atom community. 
+              To install new themes, click on \"+ Install\" and switch the toggle to \"themes\"."
+    note:
+      text1: "Next time:"
+      text2: " You can switch themes from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: "Customize the "
+      text2: "Styling"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "You can customize almost anything by adding your own CSS/LESS." 
+    'open-stylesheet': "Open your Stylesheet"
+    detail2: "Now uncomment some of the examples or try your own" 
+    note:
+      text1: "Next time:"
+      text2: " You can open your stylesheet from Menu File."
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: "Hack on the "
+      text2: "Init Script"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "The init script is a bit of JavaScript or CoffeeScript run at startup. You can use it to quickly change the behaviour of Atom."
+    'open-init-script': "Open your Init Script"
+    detail2: "Uncomment some of the examples or try out your own." 
+    note:
+      text1: "Next time:"
+      text2: " You can open your init script from Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: "Add a "
+      text2: "Snippet"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom snippets allow you to enter a simple prefix in the editor and hit tab to expand the prefix into a larger code block with templated values."
+    'open-snippet': "Open your Snippets"
+    detail2: "In your snippets file, type <code>snip</code> then hit <code>tab</code>. The <code>snip</code> snippet will expand to create a snippet!"
+    note:
+      text1: "Next time:"
+      text2: " You can open your snippets in Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: "Learn "
+      text2: "Keyboard Shortcuts"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "If you only remember one keyboard shortcut make it "
+      text2: ". This keystroke toggles the command palette, which lists every Atom command.
+              It's a good way to learn more shortcuts. Yes, you can try it now!"
+      text3: "If you want to use these guides again use the command palette "
+      text4: " and search for "
+      text5: "Welcome"
+      text6: "."
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/ms/welcome.cson
+++ b/def/ms/welcome.cson
@@ -1,29 +1,24 @@
 Welcome:
   tabTitle: "Selamat Datang"
-  subtitle: {
+  subtitle:
     text1: "Penyunting teks yang boleh digodam untuk"
     superscript: ""
     text2: " Abad Ke-21"
-  }
-  help: {
+  help:
     forHelpVisit: "Untuk bantuan, layari"
-    atomDocs: {
+    atomDocs:
       text1: ""
       link: "Dokumen-dokumen Atom"
       text2: " untuk Panduan Pengguna serta rujukan API."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomForum: {
+    atomForum:
       text1: "Forum berkaitan Atom di "
       link: "discuss.atom.io"
       text2: ""   # optional
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomOrg: {
+    atomOrg:
       text1: "Laman "
       link: "Atom org"
       text2: ". Di sinilah tempat berkumpulnya pakej-pakej Atom yang dihasilkan dari Github."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-  }
   showWelcomeGuide: "Tunjukkan tetingkap Selamat Datang ketika membuka Atom."

--- a/def/nl/consent.cson
+++ b/def/nl/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "Telemetry Consent"
+  desc:
+    text1: "Help improve Atom by sending your anonymous "
+    text2: "usage data"
+    text3: " to the Atom team. The resulting data plays a key role in deciding what we focus on next."
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "Yes, send my usage data"
+    notes:
+      text1: "Including exception and crash reports. See the "
+      text2: "atom/metrics package"
+      text3: " for more details."
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "No, do not send my usage data"
+    notes: "Note: We only register anonymously that you opted-out."
+  with: " with "
+  by: " by "

--- a/def/nl/guide.cson
+++ b/def/nl/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "Welcome Guide"
+  subTitle: "Get to know Atom!"
+  project:
+    title:
+      text1: "Open a "
+      text2: "Project"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "In Atom you can open individual files or a whole folder as a project. 
+             Opening a folder will add a tree view to the editor where you can browse all the files."
+    'open-project': "Open a Project"
+    note:
+      text1: "Next time:"
+      text2: " You can also open projects from the menu, keyboard shortcut or by dragging a folder onto the Atom dock icon."
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: "Version control with "
+      text2: "Git and GitHub"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Track changes to your code as you work. Branch, commit, push, and pull without leaving the comfort of your editor.
+             Collaborate with other developers on GitHub."
+    'open-git': "Open the Git panel"
+    'open-github': "Open the GitHub panel"
+    note:
+      text1: "Next time:"
+      text2: " You can toggle the Git tab by clicking on the "
+      text3: " button in your status bar."
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: "Collaborate in real time with "
+      text2: "Teletype"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Share your workspace with team members and collaborate on code in real time."
+    'install-teletype': "Install Teletype for Atom"
+  packages:
+    title:
+      text1: "Install a "
+      text2: "Package"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "One of the best things about Atom is the package ecosystem.
+             Installing packages adds new features and functionality you can use to make the editor suit your needs. Let's install one."
+    'install-package': "Open Installer"
+    note:
+      text1: "Next time:"
+      text2: " You can install new packages from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: "Choose a "
+      text2: "Theme"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom comes with preinstalled themes. Let's try a few."
+    'open-theme': "Open the theme picker"
+    detail2: "You can also install themes created by the Atom community. 
+              To install new themes, click on \"+ Install\" and switch the toggle to \"themes\"."
+    note:
+      text1: "Next time:"
+      text2: " You can switch themes from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: "Customize the "
+      text2: "Styling"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "You can customize almost anything by adding your own CSS/LESS." 
+    'open-stylesheet': "Open your Stylesheet"
+    detail2: "Now uncomment some of the examples or try your own" 
+    note:
+      text1: "Next time:"
+      text2: " You can open your stylesheet from Menu File."
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: "Hack on the "
+      text2: "Init Script"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "The init script is a bit of JavaScript or CoffeeScript run at startup. You can use it to quickly change the behaviour of Atom."
+    'open-init-script': "Open your Init Script"
+    detail2: "Uncomment some of the examples or try out your own." 
+    note:
+      text1: "Next time:"
+      text2: " You can open your init script from Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: "Add a "
+      text2: "Snippet"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom snippets allow you to enter a simple prefix in the editor and hit tab to expand the prefix into a larger code block with templated values."
+    'open-snippet': "Open your Snippets"
+    detail2: "In your snippets file, type <code>snip</code> then hit <code>tab</code>. The <code>snip</code> snippet will expand to create a snippet!"
+    note:
+      text1: "Next time:"
+      text2: " You can open your snippets in Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: "Learn "
+      text2: "Keyboard Shortcuts"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "If you only remember one keyboard shortcut make it "
+      text2: ". This keystroke toggles the command palette, which lists every Atom command.
+              It's a good way to learn more shortcuts. Yes, you can try it now!"
+      text3: "If you want to use these guides again use the command palette "
+      text4: " and search for "
+      text5: "Welcome"
+      text6: "."
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/nl/welcome.cson
+++ b/def/nl/welcome.cson
@@ -1,29 +1,24 @@
 Welcome:
   tabTitle: "Welcome"
-  subtitle: {
+  subtitle:
     text1: "A hackable text editor for the 21"
     superscript: "st"
     text2: " Century"
-  }
-  help: {
+  help:
     forHelpVisit: "For help, please visit"
-    atomDocs: {
+    atomDocs:
       text1: "The "
       link: "Atom docs"
       text2: " for Guides and the API reference."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomForum: {
+    atomForum:
       text1: "The Atom forum at "
       link: "discuss.atom.io"
       text2: ""   # optional
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomOrg: {
+    atomOrg:
       text1: "The "
       link: "Atom org"
       text2: ". This is where all GitHub-created Atom packages can be found."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-  }
   showWelcomeGuide: "Show Welcome Guide when opening Atom"

--- a/def/pl/consent.cson
+++ b/def/pl/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "Telemetry Consent"
+  desc:
+    text1: "Help improve Atom by sending your anonymous "
+    text2: "usage data"
+    text3: " to the Atom team. The resulting data plays a key role in deciding what we focus on next."
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "Yes, send my usage data"
+    notes:
+      text1: "Including exception and crash reports. See the "
+      text2: "atom/metrics package"
+      text3: " for more details."
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "No, do not send my usage data"
+    notes: "Note: We only register anonymously that you opted-out."
+  with: " with "
+  by: " by "

--- a/def/pl/guide.cson
+++ b/def/pl/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "Welcome Guide"
+  subTitle: "Get to know Atom!"
+  project:
+    title:
+      text1: "Open a "
+      text2: "Project"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "In Atom you can open individual files or a whole folder as a project. 
+             Opening a folder will add a tree view to the editor where you can browse all the files."
+    'open-project': "Open a Project"
+    note:
+      text1: "Next time:"
+      text2: " You can also open projects from the menu, keyboard shortcut or by dragging a folder onto the Atom dock icon."
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: "Version control with "
+      text2: "Git and GitHub"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Track changes to your code as you work. Branch, commit, push, and pull without leaving the comfort of your editor.
+             Collaborate with other developers on GitHub."
+    'open-git': "Open the Git panel"
+    'open-github': "Open the GitHub panel"
+    note:
+      text1: "Next time:"
+      text2: " You can toggle the Git tab by clicking on the "
+      text3: " button in your status bar."
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: "Collaborate in real time with "
+      text2: "Teletype"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Share your workspace with team members and collaborate on code in real time."
+    'install-teletype': "Install Teletype for Atom"
+  packages:
+    title:
+      text1: "Install a "
+      text2: "Package"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "One of the best things about Atom is the package ecosystem.
+             Installing packages adds new features and functionality you can use to make the editor suit your needs. Let's install one."
+    'install-package': "Open Installer"
+    note:
+      text1: "Next time:"
+      text2: " You can install new packages from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: "Choose a "
+      text2: "Theme"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom comes with preinstalled themes. Let's try a few."
+    'open-theme': "Open the theme picker"
+    detail2: "You can also install themes created by the Atom community. 
+              To install new themes, click on \"+ Install\" and switch the toggle to \"themes\"."
+    note:
+      text1: "Next time:"
+      text2: " You can switch themes from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: "Customize the "
+      text2: "Styling"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "You can customize almost anything by adding your own CSS/LESS." 
+    'open-stylesheet': "Open your Stylesheet"
+    detail2: "Now uncomment some of the examples or try your own" 
+    note:
+      text1: "Next time:"
+      text2: " You can open your stylesheet from Menu File."
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: "Hack on the "
+      text2: "Init Script"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "The init script is a bit of JavaScript or CoffeeScript run at startup. You can use it to quickly change the behaviour of Atom."
+    'open-init-script': "Open your Init Script"
+    detail2: "Uncomment some of the examples or try out your own." 
+    note:
+      text1: "Next time:"
+      text2: " You can open your init script from Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: "Add a "
+      text2: "Snippet"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom snippets allow you to enter a simple prefix in the editor and hit tab to expand the prefix into a larger code block with templated values."
+    'open-snippet': "Open your Snippets"
+    detail2: "In your snippets file, type <code>snip</code> then hit <code>tab</code>. The <code>snip</code> snippet will expand to create a snippet!"
+    note:
+      text1: "Next time:"
+      text2: " You can open your snippets in Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: "Learn "
+      text2: "Keyboard Shortcuts"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "If you only remember one keyboard shortcut make it "
+      text2: ". This keystroke toggles the command palette, which lists every Atom command.
+              It's a good way to learn more shortcuts. Yes, you can try it now!"
+      text3: "If you want to use these guides again use the command palette "
+      text4: " and search for "
+      text5: "Welcome"
+      text6: "."
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/pl/welcome.cson
+++ b/def/pl/welcome.cson
@@ -1,29 +1,24 @@
 Welcome:
   tabTitle: "Witaj"
-  subtitle: {
+  subtitle:
     text1: "Hakowalny edytor tekstowy 21"
     superscript: ""
     text2: " wieku"
-  }
-  help: {
+  help:
     forHelpVisit: "Jeżeli potrzebujesz pomocy, odwiedź:"
-    atomDocs: {
+    atomDocs:
       text1: ""
       link: "Dokumentacja Atom'a"
       text2: " zawiera przewodniki oraz dokumentację API."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomForum: {
+    atomForum:
       text1: "Forum Atom'a "
       link: "discuss.atom.io"
       text2: ""   # optional
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomOrg: {
+    atomOrg:
       text1: ""
       link: "Atom org"
       text2: ". Tu znajdziesz wszystkie stworzone na GitHubi'e pakiety dla Atom'a."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-  }
   showWelcomeGuide: "Pokaż ten ekran powitalny podczas uruchomienia Atom'a"

--- a/def/pt-br/consent.cson
+++ b/def/pt-br/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "Telemetry Consent"
+  desc:
+    text1: "Help improve Atom by sending your anonymous "
+    text2: "usage data"
+    text3: " to the Atom team. The resulting data plays a key role in deciding what we focus on next."
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "Yes, send my usage data"
+    notes:
+      text1: "Including exception and crash reports. See the "
+      text2: "atom/metrics package"
+      text3: " for more details."
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "No, do not send my usage data"
+    notes: "Note: We only register anonymously that you opted-out."
+  with: " with "
+  by: " by "

--- a/def/pt-br/guide.cson
+++ b/def/pt-br/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "Welcome Guide"
+  subTitle: "Get to know Atom!"
+  project:
+    title:
+      text1: "Open a "
+      text2: "Project"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "In Atom you can open individual files or a whole folder as a project. 
+             Opening a folder will add a tree view to the editor where you can browse all the files."
+    'open-project': "Open a Project"
+    note:
+      text1: "Next time:"
+      text2: " You can also open projects from the menu, keyboard shortcut or by dragging a folder onto the Atom dock icon."
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: "Version control with "
+      text2: "Git and GitHub"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Track changes to your code as you work. Branch, commit, push, and pull without leaving the comfort of your editor.
+             Collaborate with other developers on GitHub."
+    'open-git': "Open the Git panel"
+    'open-github': "Open the GitHub panel"
+    note:
+      text1: "Next time:"
+      text2: " You can toggle the Git tab by clicking on the "
+      text3: " button in your status bar."
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: "Collaborate in real time with "
+      text2: "Teletype"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Share your workspace with team members and collaborate on code in real time."
+    'install-teletype': "Install Teletype for Atom"
+  packages:
+    title:
+      text1: "Install a "
+      text2: "Package"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "One of the best things about Atom is the package ecosystem.
+             Installing packages adds new features and functionality you can use to make the editor suit your needs. Let's install one."
+    'install-package': "Open Installer"
+    note:
+      text1: "Next time:"
+      text2: " You can install new packages from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: "Choose a "
+      text2: "Theme"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom comes with preinstalled themes. Let's try a few."
+    'open-theme': "Open the theme picker"
+    detail2: "You can also install themes created by the Atom community. 
+              To install new themes, click on \"+ Install\" and switch the toggle to \"themes\"."
+    note:
+      text1: "Next time:"
+      text2: " You can switch themes from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: "Customize the "
+      text2: "Styling"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "You can customize almost anything by adding your own CSS/LESS." 
+    'open-stylesheet': "Open your Stylesheet"
+    detail2: "Now uncomment some of the examples or try your own" 
+    note:
+      text1: "Next time:"
+      text2: " You can open your stylesheet from Menu File."
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: "Hack on the "
+      text2: "Init Script"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "The init script is a bit of JavaScript or CoffeeScript run at startup. You can use it to quickly change the behaviour of Atom."
+    'open-init-script': "Open your Init Script"
+    detail2: "Uncomment some of the examples or try out your own." 
+    note:
+      text1: "Next time:"
+      text2: " You can open your init script from Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: "Add a "
+      text2: "Snippet"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom snippets allow you to enter a simple prefix in the editor and hit tab to expand the prefix into a larger code block with templated values."
+    'open-snippet': "Open your Snippets"
+    detail2: "In your snippets file, type <code>snip</code> then hit <code>tab</code>. The <code>snip</code> snippet will expand to create a snippet!"
+    note:
+      text1: "Next time:"
+      text2: " You can open your snippets in Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: "Learn "
+      text2: "Keyboard Shortcuts"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "If you only remember one keyboard shortcut make it "
+      text2: ". This keystroke toggles the command palette, which lists every Atom command.
+              It's a good way to learn more shortcuts. Yes, you can try it now!"
+      text3: "If you want to use these guides again use the command palette "
+      text4: " and search for "
+      text5: "Welcome"
+      text6: "."
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/pt-br/welcome.cson
+++ b/def/pt-br/welcome.cson
@@ -1,29 +1,24 @@
 Welcome:
   tabTitle: "Bem vindo"
-  subtitle: {
+  subtitle:
     text1: "Um editor haqueável para o "
     superscript: ""
     text2: " século 21"
-  }
-  help: {
+  help:
     forHelpVisit: "Para ajuda, por favor visite"
-    atomDocs: {
+    atomDocs:
       text1: "Os "
       link: "documentos Atom"
       text2: " para guias e referências de API."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomForum: {
+    atomForum:
       text1: "O fórum Atom em "
       link: "discuss.atom.io"
       text2: ""   # optional
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomOrg: {
+    atomOrg:
       text1: "O "
       link: "Atom org"
       text2: ". É aqui que todos os pacotes Atom criados pelo GitHub podem ser encontrados."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-  }
   showWelcomeGuide: "Exibir guia de boas vindas quando abrir o Atom"

--- a/def/ro/consent.cson
+++ b/def/ro/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "Telemetry Consent"
+  desc:
+    text1: "Help improve Atom by sending your anonymous "
+    text2: "usage data"
+    text3: " to the Atom team. The resulting data plays a key role in deciding what we focus on next."
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "Yes, send my usage data"
+    notes:
+      text1: "Including exception and crash reports. See the "
+      text2: "atom/metrics package"
+      text3: " for more details."
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "No, do not send my usage data"
+    notes: "Note: We only register anonymously that you opted-out."
+  with: " with "
+  by: " by "

--- a/def/ro/guide.cson
+++ b/def/ro/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "Welcome Guide"
+  subTitle: "Get to know Atom!"
+  project:
+    title:
+      text1: "Open a "
+      text2: "Project"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "In Atom you can open individual files or a whole folder as a project. 
+             Opening a folder will add a tree view to the editor where you can browse all the files."
+    'open-project': "Open a Project"
+    note:
+      text1: "Next time:"
+      text2: " You can also open projects from the menu, keyboard shortcut or by dragging a folder onto the Atom dock icon."
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: "Version control with "
+      text2: "Git and GitHub"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Track changes to your code as you work. Branch, commit, push, and pull without leaving the comfort of your editor.
+             Collaborate with other developers on GitHub."
+    'open-git': "Open the Git panel"
+    'open-github': "Open the GitHub panel"
+    note:
+      text1: "Next time:"
+      text2: " You can toggle the Git tab by clicking on the "
+      text3: " button in your status bar."
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: "Collaborate in real time with "
+      text2: "Teletype"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Share your workspace with team members and collaborate on code in real time."
+    'install-teletype': "Install Teletype for Atom"
+  packages:
+    title:
+      text1: "Install a "
+      text2: "Package"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "One of the best things about Atom is the package ecosystem.
+             Installing packages adds new features and functionality you can use to make the editor suit your needs. Let's install one."
+    'install-package': "Open Installer"
+    note:
+      text1: "Next time:"
+      text2: " You can install new packages from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: "Choose a "
+      text2: "Theme"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom comes with preinstalled themes. Let's try a few."
+    'open-theme': "Open the theme picker"
+    detail2: "You can also install themes created by the Atom community. 
+              To install new themes, click on \"+ Install\" and switch the toggle to \"themes\"."
+    note:
+      text1: "Next time:"
+      text2: " You can switch themes from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: "Customize the "
+      text2: "Styling"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "You can customize almost anything by adding your own CSS/LESS." 
+    'open-stylesheet': "Open your Stylesheet"
+    detail2: "Now uncomment some of the examples or try your own" 
+    note:
+      text1: "Next time:"
+      text2: " You can open your stylesheet from Menu File."
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: "Hack on the "
+      text2: "Init Script"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "The init script is a bit of JavaScript or CoffeeScript run at startup. You can use it to quickly change the behaviour of Atom."
+    'open-init-script': "Open your Init Script"
+    detail2: "Uncomment some of the examples or try out your own." 
+    note:
+      text1: "Next time:"
+      text2: " You can open your init script from Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: "Add a "
+      text2: "Snippet"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom snippets allow you to enter a simple prefix in the editor and hit tab to expand the prefix into a larger code block with templated values."
+    'open-snippet': "Open your Snippets"
+    detail2: "In your snippets file, type <code>snip</code> then hit <code>tab</code>. The <code>snip</code> snippet will expand to create a snippet!"
+    note:
+      text1: "Next time:"
+      text2: " You can open your snippets in Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: "Learn "
+      text2: "Keyboard Shortcuts"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "If you only remember one keyboard shortcut make it "
+      text2: ". This keystroke toggles the command palette, which lists every Atom command.
+              It's a good way to learn more shortcuts. Yes, you can try it now!"
+      text3: "If you want to use these guides again use the command palette "
+      text4: " and search for "
+      text5: "Welcome"
+      text6: "."
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/ro/welcome.cson
+++ b/def/ro/welcome.cson
@@ -1,29 +1,24 @@
 Welcome:
   tabTitle: "Bine ai venit"
-  subtitle: {
+  subtitle:
     text1: "Un editor de text ultra-configurabil pentru secolul 21"
     superscript: ""
     text2: ""
-  }
-  help: {
+  help:
     forHelpVisit: "Ai nevoie de ajutor? Vizitează"
-    atomDocs: {
+    atomDocs:
       text1: ""
       link: "Documentația Atom"
       text2: " pentru ghiduri și referințele API-ului."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomForum: {
+    atomForum:
       text1: "Forumul atom la "
       link: "discuss.atom.io"
       text2: ""   # optional
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomOrg: {
+    atomOrg:
       text1: ""
       link: "Atom org"
       text2: ". Aici puteți găsi toate pachetele Atom create pe GitHub."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-  }
   showWelcomeGuide: "Arată ghidul de bun venit la deschiderea Atom"

--- a/def/ru/consent.cson
+++ b/def/ru/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "Telemetry Consent"
+  desc:
+    text1: "Help improve Atom by sending your anonymous "
+    text2: "usage data"
+    text3: " to the Atom team. The resulting data plays a key role in deciding what we focus on next."
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "Yes, send my usage data"
+    notes:
+      text1: "Including exception and crash reports. See the "
+      text2: "atom/metrics package"
+      text3: " for more details."
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "No, do not send my usage data"
+    notes: "Note: We only register anonymously that you opted-out."
+  with: " with "
+  by: " by "

--- a/def/ru/guide.cson
+++ b/def/ru/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "Welcome Guide"
+  subTitle: "Get to know Atom!"
+  project:
+    title:
+      text1: "Open a "
+      text2: "Project"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "In Atom you can open individual files or a whole folder as a project. 
+             Opening a folder will add a tree view to the editor where you can browse all the files."
+    'open-project': "Open a Project"
+    note:
+      text1: "Next time:"
+      text2: " You can also open projects from the menu, keyboard shortcut or by dragging a folder onto the Atom dock icon."
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: "Version control with "
+      text2: "Git and GitHub"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Track changes to your code as you work. Branch, commit, push, and pull without leaving the comfort of your editor.
+             Collaborate with other developers on GitHub."
+    'open-git': "Open the Git panel"
+    'open-github': "Open the GitHub panel"
+    note:
+      text1: "Next time:"
+      text2: " You can toggle the Git tab by clicking on the "
+      text3: " button in your status bar."
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: "Collaborate in real time with "
+      text2: "Teletype"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Share your workspace with team members and collaborate on code in real time."
+    'install-teletype': "Install Teletype for Atom"
+  packages:
+    title:
+      text1: "Install a "
+      text2: "Package"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "One of the best things about Atom is the package ecosystem.
+             Installing packages adds new features and functionality you can use to make the editor suit your needs. Let's install one."
+    'install-package': "Open Installer"
+    note:
+      text1: "Next time:"
+      text2: " You can install new packages from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: "Choose a "
+      text2: "Theme"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom comes with preinstalled themes. Let's try a few."
+    'open-theme': "Open the theme picker"
+    detail2: "You can also install themes created by the Atom community. 
+              To install new themes, click on \"+ Install\" and switch the toggle to \"themes\"."
+    note:
+      text1: "Next time:"
+      text2: " You can switch themes from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: "Customize the "
+      text2: "Styling"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "You can customize almost anything by adding your own CSS/LESS." 
+    'open-stylesheet': "Open your Stylesheet"
+    detail2: "Now uncomment some of the examples or try your own" 
+    note:
+      text1: "Next time:"
+      text2: " You can open your stylesheet from Menu File."
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: "Hack on the "
+      text2: "Init Script"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "The init script is a bit of JavaScript or CoffeeScript run at startup. You can use it to quickly change the behaviour of Atom."
+    'open-init-script': "Open your Init Script"
+    detail2: "Uncomment some of the examples or try out your own." 
+    note:
+      text1: "Next time:"
+      text2: " You can open your init script from Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: "Add a "
+      text2: "Snippet"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom snippets allow you to enter a simple prefix in the editor and hit tab to expand the prefix into a larger code block with templated values."
+    'open-snippet': "Open your Snippets"
+    detail2: "In your snippets file, type <code>snip</code> then hit <code>tab</code>. The <code>snip</code> snippet will expand to create a snippet!"
+    note:
+      text1: "Next time:"
+      text2: " You can open your snippets in Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: "Learn "
+      text2: "Keyboard Shortcuts"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "If you only remember one keyboard shortcut make it "
+      text2: ". This keystroke toggles the command palette, which lists every Atom command.
+              It's a good way to learn more shortcuts. Yes, you can try it now!"
+      text3: "If you want to use these guides again use the command palette "
+      text4: " and search for "
+      text5: "Welcome"
+      text6: "."
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/ru/welcome.cson
+++ b/def/ru/welcome.cson
@@ -1,29 +1,24 @@
 Welcome:
   tabTitle: "Добро пожаловать"
-  subtitle: {
+  subtitle:
     text1: "Хакабельный текстовый редактор XXI"
     superscript: ""
     text2: " века"
-  }
-  help: {
+  help:
     forHelpVisit: "Посетите "
-    atomDocs: {
+    atomDocs:
       text1: " "
       link: "Atom docs"
       text2: " для уроков и API."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomForum: {
+    atomForum:
       text1: "Форум Atom"
       link: "discuss.atom.io"
       text2: ""   # optional
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomOrg: {
+    atomOrg:
       text1: ""
       link: "Atom org"
       text2: ". Здесь находятся все расширения, созданные на GitHub."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-  }
   showWelcomeGuide: "Показывать приветствие при запуске Atom"

--- a/def/sk/consent.cson
+++ b/def/sk/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "Telemetry Consent"
+  desc:
+    text1: "Help improve Atom by sending your anonymous "
+    text2: "usage data"
+    text3: " to the Atom team. The resulting data plays a key role in deciding what we focus on next."
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "Yes, send my usage data"
+    notes:
+      text1: "Including exception and crash reports. See the "
+      text2: "atom/metrics package"
+      text3: " for more details."
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "No, do not send my usage data"
+    notes: "Note: We only register anonymously that you opted-out."
+  with: " with "
+  by: " by "

--- a/def/sk/guide.cson
+++ b/def/sk/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "Welcome Guide"
+  subTitle: "Get to know Atom!"
+  project:
+    title:
+      text1: "Open a "
+      text2: "Project"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "In Atom you can open individual files or a whole folder as a project. 
+             Opening a folder will add a tree view to the editor where you can browse all the files."
+    'open-project': "Open a Project"
+    note:
+      text1: "Next time:"
+      text2: " You can also open projects from the menu, keyboard shortcut or by dragging a folder onto the Atom dock icon."
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: "Version control with "
+      text2: "Git and GitHub"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Track changes to your code as you work. Branch, commit, push, and pull without leaving the comfort of your editor.
+             Collaborate with other developers on GitHub."
+    'open-git': "Open the Git panel"
+    'open-github': "Open the GitHub panel"
+    note:
+      text1: "Next time:"
+      text2: " You can toggle the Git tab by clicking on the "
+      text3: " button in your status bar."
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: "Collaborate in real time with "
+      text2: "Teletype"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Share your workspace with team members and collaborate on code in real time."
+    'install-teletype': "Install Teletype for Atom"
+  packages:
+    title:
+      text1: "Install a "
+      text2: "Package"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "One of the best things about Atom is the package ecosystem.
+             Installing packages adds new features and functionality you can use to make the editor suit your needs. Let's install one."
+    'install-package': "Open Installer"
+    note:
+      text1: "Next time:"
+      text2: " You can install new packages from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: "Choose a "
+      text2: "Theme"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom comes with preinstalled themes. Let's try a few."
+    'open-theme': "Open the theme picker"
+    detail2: "You can also install themes created by the Atom community. 
+              To install new themes, click on \"+ Install\" and switch the toggle to \"themes\"."
+    note:
+      text1: "Next time:"
+      text2: " You can switch themes from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: "Customize the "
+      text2: "Styling"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "You can customize almost anything by adding your own CSS/LESS." 
+    'open-stylesheet': "Open your Stylesheet"
+    detail2: "Now uncomment some of the examples or try your own" 
+    note:
+      text1: "Next time:"
+      text2: " You can open your stylesheet from Menu File."
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: "Hack on the "
+      text2: "Init Script"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "The init script is a bit of JavaScript or CoffeeScript run at startup. You can use it to quickly change the behaviour of Atom."
+    'open-init-script': "Open your Init Script"
+    detail2: "Uncomment some of the examples or try out your own." 
+    note:
+      text1: "Next time:"
+      text2: " You can open your init script from Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: "Add a "
+      text2: "Snippet"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom snippets allow you to enter a simple prefix in the editor and hit tab to expand the prefix into a larger code block with templated values."
+    'open-snippet': "Open your Snippets"
+    detail2: "In your snippets file, type <code>snip</code> then hit <code>tab</code>. The <code>snip</code> snippet will expand to create a snippet!"
+    note:
+      text1: "Next time:"
+      text2: " You can open your snippets in Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: "Learn "
+      text2: "Keyboard Shortcuts"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "If you only remember one keyboard shortcut make it "
+      text2: ". This keystroke toggles the command palette, which lists every Atom command.
+              It's a good way to learn more shortcuts. Yes, you can try it now!"
+      text3: "If you want to use these guides again use the command palette "
+      text4: " and search for "
+      text5: "Welcome"
+      text6: "."
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/sk/welcome.cson
+++ b/def/sk/welcome.cson
@@ -1,29 +1,24 @@
 Welcome:
   tabTitle: "Vitajte"
-  subtitle: {
+  subtitle:
     text1: "Modifikovateľný editor pre 21"
     superscript: ""
     text2: " storočie"
-  }
-  help: {
+  help:
     forHelpVisit: "Pre pomoc prosím navštívte"
-    atomDocs: {
+    atomDocs:
       text1: ""
       link: "Dokumentáciu Atomu"
       text2: " pre Návody a API REFERENCIE."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomForum: {
+    atomForum:
       text1: "Fórum atomu na: "
       link: "discuss.atom.io"
       text2: ""   # optional
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomOrg: {
+    atomOrg:
       text1: ""
       link: "Atom org"
       text2: ". Tuto nájdete všetky pluginy z Githubu pre Atom."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-  }
   showWelcomeGuide: "Zobraziť obrazovku \"Vitajte\" pri spustení Atomu"

--- a/def/sq/consent.cson
+++ b/def/sq/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "Telemetry Consent"
+  desc:
+    text1: "Help improve Atom by sending your anonymous "
+    text2: "usage data"
+    text3: " to the Atom team. The resulting data plays a key role in deciding what we focus on next."
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "Yes, send my usage data"
+    notes:
+      text1: "Including exception and crash reports. See the "
+      text2: "atom/metrics package"
+      text3: " for more details."
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "No, do not send my usage data"
+    notes: "Note: We only register anonymously that you opted-out."
+  with: " with "
+  by: " by "

--- a/def/sq/guide.cson
+++ b/def/sq/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "Welcome Guide"
+  subTitle: "Get to know Atom!"
+  project:
+    title:
+      text1: "Open a "
+      text2: "Project"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "In Atom you can open individual files or a whole folder as a project. 
+             Opening a folder will add a tree view to the editor where you can browse all the files."
+    'open-project': "Open a Project"
+    note:
+      text1: "Next time:"
+      text2: " You can also open projects from the menu, keyboard shortcut or by dragging a folder onto the Atom dock icon."
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: "Version control with "
+      text2: "Git and GitHub"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Track changes to your code as you work. Branch, commit, push, and pull without leaving the comfort of your editor.
+             Collaborate with other developers on GitHub."
+    'open-git': "Open the Git panel"
+    'open-github': "Open the GitHub panel"
+    note:
+      text1: "Next time:"
+      text2: " You can toggle the Git tab by clicking on the "
+      text3: " button in your status bar."
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: "Collaborate in real time with "
+      text2: "Teletype"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Share your workspace with team members and collaborate on code in real time."
+    'install-teletype': "Install Teletype for Atom"
+  packages:
+    title:
+      text1: "Install a "
+      text2: "Package"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "One of the best things about Atom is the package ecosystem.
+             Installing packages adds new features and functionality you can use to make the editor suit your needs. Let's install one."
+    'install-package': "Open Installer"
+    note:
+      text1: "Next time:"
+      text2: " You can install new packages from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: "Choose a "
+      text2: "Theme"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom comes with preinstalled themes. Let's try a few."
+    'open-theme': "Open the theme picker"
+    detail2: "You can also install themes created by the Atom community. 
+              To install new themes, click on \"+ Install\" and switch the toggle to \"themes\"."
+    note:
+      text1: "Next time:"
+      text2: " You can switch themes from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: "Customize the "
+      text2: "Styling"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "You can customize almost anything by adding your own CSS/LESS." 
+    'open-stylesheet': "Open your Stylesheet"
+    detail2: "Now uncomment some of the examples or try your own" 
+    note:
+      text1: "Next time:"
+      text2: " You can open your stylesheet from Menu File."
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: "Hack on the "
+      text2: "Init Script"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "The init script is a bit of JavaScript or CoffeeScript run at startup. You can use it to quickly change the behaviour of Atom."
+    'open-init-script': "Open your Init Script"
+    detail2: "Uncomment some of the examples or try out your own." 
+    note:
+      text1: "Next time:"
+      text2: " You can open your init script from Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: "Add a "
+      text2: "Snippet"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom snippets allow you to enter a simple prefix in the editor and hit tab to expand the prefix into a larger code block with templated values."
+    'open-snippet': "Open your Snippets"
+    detail2: "In your snippets file, type <code>snip</code> then hit <code>tab</code>. The <code>snip</code> snippet will expand to create a snippet!"
+    note:
+      text1: "Next time:"
+      text2: " You can open your snippets in Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: "Learn "
+      text2: "Keyboard Shortcuts"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "If you only remember one keyboard shortcut make it "
+      text2: ". This keystroke toggles the command palette, which lists every Atom command.
+              It's a good way to learn more shortcuts. Yes, you can try it now!"
+      text3: "If you want to use these guides again use the command palette "
+      text4: " and search for "
+      text5: "Welcome"
+      text6: "."
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/sq/welcome.cson
+++ b/def/sq/welcome.cson
@@ -1,29 +1,24 @@
 Welcome:
   tabTitle: "Mirë se vini"
-  subtitle: {
+  subtitle:
     text1: "Një përpunues tekstesh i hack-ueshëm, për shekullin e"
     superscript: ""
     text2: " 21-të"
-  }
-  help: {
+  help:
     forHelpVisit: "Për ndihmë, ju lutemi, vizitoni"
-    atomDocs: {
+    atomDocs:
       text1: ""
       link: "dokumentimin e Atom-it"
       text2: " për Udhërrëfyes dhe referencë të API-t."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomForum: {
+    atomForum:
       text1: "Forumin për Atom-in te "
       link: "discuss.atom.io"
       text2: ""   # optional
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomOrg: {
+    atomOrg:
       text1: ""
       link: "Atom org"
       text2: ". Këtu mund të gjeni krejt paketat Atom të krijuara në GitHub."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-  }
   showWelcomeGuide: "Shfaqe turin e Mirëseardhjes kur hapet Atom-i"

--- a/def/template/consent.cson
+++ b/def/template/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "Telemetry Consent"
+  desc:
+    text1: "Help improve Atom by sending your anonymous "
+    text2: "usage data"
+    text3: " to the Atom team. The resulting data plays a key role in deciding what we focus on next."
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "Yes, send my usage data"
+    notes:
+      text1: "Including exception and crash reports. See the "
+      text2: "atom/metrics package"
+      text3: " for more details."
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "No, do not send my usage data"
+    notes: "Note: We only register anonymously that you opted-out."
+  with: " with "
+  by: " by "

--- a/def/template/guide.cson
+++ b/def/template/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "Welcome Guide"
+  subTitle: "Get to know Atom!"
+  project:
+    title:
+      text1: "Open a "
+      text2: "Project"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "In Atom you can open individual files or a whole folder as a project. 
+             Opening a folder will add a tree view to the editor where you can browse all the files."
+    'open-project': "Open a Project"
+    note:
+      text1: "Next time:"
+      text2: " You can also open projects from the menu, keyboard shortcut or by dragging a folder onto the Atom dock icon."
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: "Version control with "
+      text2: "Git and GitHub"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Track changes to your code as you work. Branch, commit, push, and pull without leaving the comfort of your editor.
+             Collaborate with other developers on GitHub."
+    'open-git': "Open the Git panel"
+    'open-github': "Open the GitHub panel"
+    note:
+      text1: "Next time:"
+      text2: " You can toggle the Git tab by clicking on the "
+      text3: " button in your status bar."
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: "Collaborate in real time with "
+      text2: "Teletype"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Share your workspace with team members and collaborate on code in real time."
+    'install-teletype': "Install Teletype for Atom"
+  packages:
+    title:
+      text1: "Install a "
+      text2: "Package"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "One of the best things about Atom is the package ecosystem.
+             Installing packages adds new features and functionality you can use to make the editor suit your needs. Let's install one."
+    'install-package': "Open Installer"
+    note:
+      text1: "Next time:"
+      text2: " You can install new packages from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: "Choose a "
+      text2: "Theme"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom comes with preinstalled themes. Let's try a few."
+    'open-theme': "Open the theme picker"
+    detail2: "You can also install themes created by the Atom community. 
+              To install new themes, click on \"+ Install\" and switch the toggle to \"themes\"."
+    note:
+      text1: "Next time:"
+      text2: " You can switch themes from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: "Customize the "
+      text2: "Styling"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "You can customize almost anything by adding your own CSS/LESS." 
+    'open-stylesheet': "Open your Stylesheet"
+    detail2: "Now uncomment some of the examples or try your own" 
+    note:
+      text1: "Next time:"
+      text2: " You can open your stylesheet from Menu File."
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: "Hack on the "
+      text2: "Init Script"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "The init script is a bit of JavaScript or CoffeeScript run at startup. You can use it to quickly change the behaviour of Atom."
+    'open-init-script': "Open your Init Script"
+    detail2: "Uncomment some of the examples or try out your own." 
+    note:
+      text1: "Next time:"
+      text2: " You can open your init script from Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: "Add a "
+      text2: "Snippet"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom snippets allow you to enter a simple prefix in the editor and hit tab to expand the prefix into a larger code block with templated values."
+    'open-snippet': "Open your Snippets"
+    detail2: "In your snippets file, type <code>snip</code> then hit <code>tab</code>. The <code>snip</code> snippet will expand to create a snippet!"
+    note:
+      text1: "Next time:"
+      text2: " You can open your snippets in Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: "Learn "
+      text2: "Keyboard Shortcuts"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "If you only remember one keyboard shortcut make it "
+      text2: ". This keystroke toggles the command palette, which lists every Atom command.
+              It's a good way to learn more shortcuts. Yes, you can try it now!"
+      text3: "If you want to use these guides again use the command palette "
+      text4: " and search for "
+      text5: "Welcome"
+      text6: "."
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/template/welcome.cson
+++ b/def/template/welcome.cson
@@ -1,29 +1,24 @@
 Welcome:
   tabTitle: "Welcome"
-  subtitle: {
+  subtitle:
     text1: "A hackable text editor for the 21"
     superscript: "st"
     text2: " Century"
-  }
-  help: {
+  help:
     forHelpVisit: "For help, please visit"
-    atomDocs: {
+    atomDocs:
       text1: "The "
       link: "Atom docs"
       text2: " for Guides and the API reference."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomForum: {
+    atomForum:
       text1: "The Atom forum at "
       link: "discuss.atom.io"
       text2: ""   # optional
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomOrg: {
+    atomOrg:
       text1: "The "
       link: "Atom org"
       text2: ". This is where all GitHub-created Atom packages can be found."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-  }
   showWelcomeGuide: "Show Welcome Guide when opening Atom"

--- a/def/th/consent.cson
+++ b/def/th/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "Telemetry Consent"
+  desc:
+    text1: "Help improve Atom by sending your anonymous "
+    text2: "usage data"
+    text3: " to the Atom team. The resulting data plays a key role in deciding what we focus on next."
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "Yes, send my usage data"
+    notes:
+      text1: "Including exception and crash reports. See the "
+      text2: "atom/metrics package"
+      text3: " for more details."
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "No, do not send my usage data"
+    notes: "Note: We only register anonymously that you opted-out."
+  with: " with "
+  by: " by "

--- a/def/th/guide.cson
+++ b/def/th/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "Welcome Guide"
+  subTitle: "Get to know Atom!"
+  project:
+    title:
+      text1: "Open a "
+      text2: "Project"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "In Atom you can open individual files or a whole folder as a project. 
+             Opening a folder will add a tree view to the editor where you can browse all the files."
+    'open-project': "Open a Project"
+    note:
+      text1: "Next time:"
+      text2: " You can also open projects from the menu, keyboard shortcut or by dragging a folder onto the Atom dock icon."
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: "Version control with "
+      text2: "Git and GitHub"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Track changes to your code as you work. Branch, commit, push, and pull without leaving the comfort of your editor.
+             Collaborate with other developers on GitHub."
+    'open-git': "Open the Git panel"
+    'open-github': "Open the GitHub panel"
+    note:
+      text1: "Next time:"
+      text2: " You can toggle the Git tab by clicking on the "
+      text3: " button in your status bar."
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: "Collaborate in real time with "
+      text2: "Teletype"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Share your workspace with team members and collaborate on code in real time."
+    'install-teletype': "Install Teletype for Atom"
+  packages:
+    title:
+      text1: "Install a "
+      text2: "Package"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "One of the best things about Atom is the package ecosystem.
+             Installing packages adds new features and functionality you can use to make the editor suit your needs. Let's install one."
+    'install-package': "Open Installer"
+    note:
+      text1: "Next time:"
+      text2: " You can install new packages from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: "Choose a "
+      text2: "Theme"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom comes with preinstalled themes. Let's try a few."
+    'open-theme': "Open the theme picker"
+    detail2: "You can also install themes created by the Atom community. 
+              To install new themes, click on \"+ Install\" and switch the toggle to \"themes\"."
+    note:
+      text1: "Next time:"
+      text2: " You can switch themes from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: "Customize the "
+      text2: "Styling"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "You can customize almost anything by adding your own CSS/LESS." 
+    'open-stylesheet': "Open your Stylesheet"
+    detail2: "Now uncomment some of the examples or try your own" 
+    note:
+      text1: "Next time:"
+      text2: " You can open your stylesheet from Menu File."
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: "Hack on the "
+      text2: "Init Script"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "The init script is a bit of JavaScript or CoffeeScript run at startup. You can use it to quickly change the behaviour of Atom."
+    'open-init-script': "Open your Init Script"
+    detail2: "Uncomment some of the examples or try out your own." 
+    note:
+      text1: "Next time:"
+      text2: " You can open your init script from Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: "Add a "
+      text2: "Snippet"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom snippets allow you to enter a simple prefix in the editor and hit tab to expand the prefix into a larger code block with templated values."
+    'open-snippet': "Open your Snippets"
+    detail2: "In your snippets file, type <code>snip</code> then hit <code>tab</code>. The <code>snip</code> snippet will expand to create a snippet!"
+    note:
+      text1: "Next time:"
+      text2: " You can open your snippets in Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: "Learn "
+      text2: "Keyboard Shortcuts"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "If you only remember one keyboard shortcut make it "
+      text2: ". This keystroke toggles the command palette, which lists every Atom command.
+              It's a good way to learn more shortcuts. Yes, you can try it now!"
+      text3: "If you want to use these guides again use the command palette "
+      text4: " and search for "
+      text5: "Welcome"
+      text6: "."
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/th/welcome.cson
+++ b/def/th/welcome.cson
@@ -1,29 +1,24 @@
 Welcome:
   tabTitle: "ยินดีต้นรับ"
-  subtitle: {
+  subtitle:
     text1: "อิดิเตอร์ที่แฮคได้ของศตวรรษที่ 21"
     superscript: " st"
     text2: " "
-  }
-  help: {
+  help:
     forHelpVisit: "สำหรับความช่วยเหลือ, โปรดเข้าไปที่ "
-    atomDocs: {
+    atomDocs:
       text1: " "
       link: "เอกสารของ Atom"
       text2: " สำหรับแนวทางและคู่มือ API"
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomForum: {
+    atomForum:
       text1: "กระทู้ของ Atom ที่ "
       link: "discuss.atom.io"
       text2: " "   # optional
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomOrg: {
+    atomOrg:
       text1: " "
       link: "Atom org"
       text2: " คือที่ที่จะพบแพคเก็จของ Atom ที่สร้างบน Github"
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-  }
   showWelcomeGuide: "แสดงข้อความต้อนรับเมื่อเริ่มเปิด Atom"

--- a/def/uk/consent.cson
+++ b/def/uk/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "Telemetry Consent"
+  desc:
+    text1: "Help improve Atom by sending your anonymous "
+    text2: "usage data"
+    text3: " to the Atom team. The resulting data plays a key role in deciding what we focus on next."
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "Yes, send my usage data"
+    notes:
+      text1: "Including exception and crash reports. See the "
+      text2: "atom/metrics package"
+      text3: " for more details."
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "No, do not send my usage data"
+    notes: "Note: We only register anonymously that you opted-out."
+  with: " with "
+  by: " by "

--- a/def/uk/guide.cson
+++ b/def/uk/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "Welcome Guide"
+  subTitle: "Get to know Atom!"
+  project:
+    title:
+      text1: "Open a "
+      text2: "Project"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "In Atom you can open individual files or a whole folder as a project. 
+             Opening a folder will add a tree view to the editor where you can browse all the files."
+    'open-project': "Open a Project"
+    note:
+      text1: "Next time:"
+      text2: " You can also open projects from the menu, keyboard shortcut or by dragging a folder onto the Atom dock icon."
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: "Version control with "
+      text2: "Git and GitHub"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Track changes to your code as you work. Branch, commit, push, and pull without leaving the comfort of your editor.
+             Collaborate with other developers on GitHub."
+    'open-git': "Open the Git panel"
+    'open-github': "Open the GitHub panel"
+    note:
+      text1: "Next time:"
+      text2: " You can toggle the Git tab by clicking on the "
+      text3: " button in your status bar."
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: "Collaborate in real time with "
+      text2: "Teletype"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Share your workspace with team members and collaborate on code in real time."
+    'install-teletype': "Install Teletype for Atom"
+  packages:
+    title:
+      text1: "Install a "
+      text2: "Package"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "One of the best things about Atom is the package ecosystem.
+             Installing packages adds new features and functionality you can use to make the editor suit your needs. Let's install one."
+    'install-package': "Open Installer"
+    note:
+      text1: "Next time:"
+      text2: " You can install new packages from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: "Choose a "
+      text2: "Theme"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom comes with preinstalled themes. Let's try a few."
+    'open-theme': "Open the theme picker"
+    detail2: "You can also install themes created by the Atom community. 
+              To install new themes, click on \"+ Install\" and switch the toggle to \"themes\"."
+    note:
+      text1: "Next time:"
+      text2: " You can switch themes from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: "Customize the "
+      text2: "Styling"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "You can customize almost anything by adding your own CSS/LESS." 
+    'open-stylesheet': "Open your Stylesheet"
+    detail2: "Now uncomment some of the examples or try your own" 
+    note:
+      text1: "Next time:"
+      text2: " You can open your stylesheet from Menu File."
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: "Hack on the "
+      text2: "Init Script"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "The init script is a bit of JavaScript or CoffeeScript run at startup. You can use it to quickly change the behaviour of Atom."
+    'open-init-script': "Open your Init Script"
+    detail2: "Uncomment some of the examples or try out your own." 
+    note:
+      text1: "Next time:"
+      text2: " You can open your init script from Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: "Add a "
+      text2: "Snippet"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom snippets allow you to enter a simple prefix in the editor and hit tab to expand the prefix into a larger code block with templated values."
+    'open-snippet': "Open your Snippets"
+    detail2: "In your snippets file, type <code>snip</code> then hit <code>tab</code>. The <code>snip</code> snippet will expand to create a snippet!"
+    note:
+      text1: "Next time:"
+      text2: " You can open your snippets in Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: "Learn "
+      text2: "Keyboard Shortcuts"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "If you only remember one keyboard shortcut make it "
+      text2: ". This keystroke toggles the command palette, which lists every Atom command.
+              It's a good way to learn more shortcuts. Yes, you can try it now!"
+      text3: "If you want to use these guides again use the command palette "
+      text4: " and search for "
+      text5: "Welcome"
+      text6: "."
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/uk/welcome.cson
+++ b/def/uk/welcome.cson
@@ -1,29 +1,24 @@
 Welcome:
   tabTitle: "Вітаємо"
-  subtitle: {
+  subtitle:
     text1: "Просунутий текстовий редактор для 21"
     superscript: "st"
     text2: " століття"
-  }
-  help: {
+  help:
     forHelpVisit: "Для отримання допомоги, будь ласка, відвідайте"
-    atomDocs: {
+    atomDocs:
       text1: " "
       link: "Atom docs"
       text2: " за посібниками та API документацією."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomForum: {
+    atomForum:
       text1: "Форум Atom на "
       link: "discuss.atom.io"
       text2: ""   # optional
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomOrg: {
+    atomOrg:
       text1: "The "
       link: "Atom org"
       text2: ". Тут знаходяться усі пакунки Atom, створені на GitHub."
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-  }
   showWelcomeGuide: "Показувати привітання при відкриті Atom"

--- a/def/zh-cn/consent.cson
+++ b/def/zh-cn/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "Telemetry Consent"
+  desc:
+    text1: "Help improve Atom by sending your anonymous "
+    text2: "usage data"
+    text3: " to the Atom team. The resulting data plays a key role in deciding what we focus on next."
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "Yes, send my usage data"
+    notes:
+      text1: "Including exception and crash reports. See the "
+      text2: "atom/metrics package"
+      text3: " for more details."
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "No, do not send my usage data"
+    notes: "Note: We only register anonymously that you opted-out."
+  with: " with "
+  by: " by "

--- a/def/zh-cn/guide.cson
+++ b/def/zh-cn/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "Welcome Guide"
+  subTitle: "Get to know Atom!"
+  project:
+    title:
+      text1: "Open a "
+      text2: "Project"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "In Atom you can open individual files or a whole folder as a project. 
+             Opening a folder will add a tree view to the editor where you can browse all the files."
+    'open-project': "Open a Project"
+    note:
+      text1: "Next time:"
+      text2: " You can also open projects from the menu, keyboard shortcut or by dragging a folder onto the Atom dock icon."
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: "Version control with "
+      text2: "Git and GitHub"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Track changes to your code as you work. Branch, commit, push, and pull without leaving the comfort of your editor.
+             Collaborate with other developers on GitHub."
+    'open-git': "Open the Git panel"
+    'open-github': "Open the GitHub panel"
+    note:
+      text1: "Next time:"
+      text2: " You can toggle the Git tab by clicking on the "
+      text3: " button in your status bar."
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: "Collaborate in real time with "
+      text2: "Teletype"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Share your workspace with team members and collaborate on code in real time."
+    'install-teletype': "Install Teletype for Atom"
+  packages:
+    title:
+      text1: "Install a "
+      text2: "Package"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "One of the best things about Atom is the package ecosystem.
+             Installing packages adds new features and functionality you can use to make the editor suit your needs. Let's install one."
+    'install-package': "Open Installer"
+    note:
+      text1: "Next time:"
+      text2: " You can install new packages from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: "Choose a "
+      text2: "Theme"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom comes with preinstalled themes. Let's try a few."
+    'open-theme': "Open the theme picker"
+    detail2: "You can also install themes created by the Atom community. 
+              To install new themes, click on \"+ Install\" and switch the toggle to \"themes\"."
+    note:
+      text1: "Next time:"
+      text2: " You can switch themes from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: "Customize the "
+      text2: "Styling"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "You can customize almost anything by adding your own CSS/LESS." 
+    'open-stylesheet': "Open your Stylesheet"
+    detail2: "Now uncomment some of the examples or try your own" 
+    note:
+      text1: "Next time:"
+      text2: " You can open your stylesheet from Menu File."
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: "Hack on the "
+      text2: "Init Script"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "The init script is a bit of JavaScript or CoffeeScript run at startup. You can use it to quickly change the behaviour of Atom."
+    'open-init-script': "Open your Init Script"
+    detail2: "Uncomment some of the examples or try out your own." 
+    note:
+      text1: "Next time:"
+      text2: " You can open your init script from Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: "Add a "
+      text2: "Snippet"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom snippets allow you to enter a simple prefix in the editor and hit tab to expand the prefix into a larger code block with templated values."
+    'open-snippet': "Open your Snippets"
+    detail2: "In your snippets file, type <code>snip</code> then hit <code>tab</code>. The <code>snip</code> snippet will expand to create a snippet!"
+    note:
+      text1: "Next time:"
+      text2: " You can open your snippets in Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: "Learn "
+      text2: "Keyboard Shortcuts"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "If you only remember one keyboard shortcut make it "
+      text2: ". This keystroke toggles the command palette, which lists every Atom command.
+              It's a good way to learn more shortcuts. Yes, you can try it now!"
+      text3: "If you want to use these guides again use the command palette "
+      text4: " and search for "
+      text5: "Welcome"
+      text6: "."
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/zh-cn/welcome.cson
+++ b/def/zh-cn/welcome.cson
@@ -1,29 +1,24 @@
 Welcome:
   tabTitle: "欢迎"
-  subtitle: {
+  subtitle:
     text1: "为21世纪打造的"
     superscript: ""
     text2: "黑客文本编辑器"
-  }
-  help: {
+  help:
     forHelpVisit: "需要帮助？"
-    atomDocs: {
+    atomDocs:
       text1: "有关使用指南及API参考，请查看 "
       link: "Atom 参考文档"
       text2: " 。"
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomForum: {
+    atomForum:
       text1: "在 Atom 论坛 "
       link: "discuss.atom.io"
       text2: " 上和大家一起讨论。"   # optional
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomOrg: {
+    atomOrg:
       text1: "在 "
       link: "GitHub 上的 Atom 组织"
       text2: " 能找到所有 GitHub 用户制作的 Atom 插件包。"
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-  }
   showWelcomeGuide: "在 Atom 启动时显示起始页"

--- a/def/zh-tw/consent.cson
+++ b/def/zh-tw/consent.cson
@@ -1,0 +1,19 @@
+Consent:
+  tabTitle: "Telemetry Consent"
+  desc:
+    text1: "Help improve Atom by sending your anonymous "
+    text2: "usage data"
+    text3: " to the Atom team. The resulting data plays a key role in deciding what we focus on next."
+    _template: "${text1}<strong>${text2}</strong>${text3}"
+  send:
+    "send-usage": "Yes, send my usage data"
+    notes:
+      text1: "Including exception and crash reports. See the "
+      text2: "atom/metrics package"
+      text3: " for more details."
+      _template: "${text1}<a>${text2}</a>${text3}"
+  unsend:
+    "unsend-usage": "No, do not send my usage data"
+    notes: "Note: We only register anonymously that you opted-out."
+  with: " with "
+  by: " by "

--- a/def/zh-tw/guide.cson
+++ b/def/zh-tw/guide.cson
@@ -1,0 +1,120 @@
+Guide:
+  tabTitle: "Welcome Guide"
+  subTitle: "Get to know Atom!"
+  project:
+    title:
+      text1: "Open a "
+      text2: "Project"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "In Atom you can open individual files or a whole folder as a project. 
+             Opening a folder will add a tree view to the editor where you can browse all the files."
+    'open-project': "Open a Project"
+    note:
+      text1: "Next time:"
+      text2: " You can also open projects from the menu, keyboard shortcut or by dragging a folder onto the Atom dock icon."
+      _template: "<strong>${text1}</strong>${text2}"
+  git:
+    title:
+      text1: "Version control with "
+      text2: "Git and GitHub"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Track changes to your code as you work. Branch, commit, push, and pull without leaving the comfort of your editor.
+             Collaborate with other developers on GitHub."
+    'open-git': "Open the Git panel"
+    'open-github': "Open the GitHub panel"
+    note:
+      text1: "Next time:"
+      text2: " You can toggle the Git tab by clicking on the "
+      text3: " button in your status bar."
+      _template: "<strong>${text1}</strong>${text2}<span></span>${text3}"
+  teletype:
+    title:
+      text1: "Collaborate in real time with "
+      text2: "Teletype"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Share your workspace with team members and collaborate on code in real time."
+    'install-teletype': "Install Teletype for Atom"
+  packages:
+    title:
+      text1: "Install a "
+      text2: "Package"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "One of the best things about Atom is the package ecosystem.
+             Installing packages adds new features and functionality you can use to make the editor suit your needs. Let's install one."
+    'install-package': "Open Installer"
+    note:
+      text1: "Next time:"
+      text2: " You can install new packages from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  themes:
+    title:
+      text1: "Choose a "
+      text2: "Theme"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "Atom comes with preinstalled themes. Let's try a few."
+    'open-theme': "Open the theme picker"
+    detail2: "You can also install themes created by the Atom community. 
+              To install new themes, click on \"+ Install\" and switch the toggle to \"themes\"."
+    note:
+      text1: "Next time:"
+      text2: " You can switch themes from the settings."
+      _template: "<strong>${text1}</strong>${text2}"
+  styling:
+    title:
+      text1: "Customize the "
+      text2: "Styling"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "You can customize almost anything by adding your own CSS/LESS." 
+    'open-stylesheet': "Open your Stylesheet"
+    detail2: "Now uncomment some of the examples or try your own" 
+    note:
+      text1: "Next time:"
+      text2: " You can open your stylesheet from Menu File."
+      _template: "<strong>${text1}</strong>${text2}"
+  'init-script':
+    title:
+      text1: "Hack on the "
+      text2: "Init Script"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail1: "The init script is a bit of JavaScript or CoffeeScript run at startup. You can use it to quickly change the behaviour of Atom."
+    'open-init-script': "Open your Init Script"
+    detail2: "Uncomment some of the examples or try out your own." 
+    note:
+      text1: "Next time:"
+      text2: " You can open your init script from Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  snippets:
+    title:
+      text1: "Add a "
+      text2: "Snippet"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: "Atom snippets allow you to enter a simple prefix in the editor and hit tab to expand the prefix into a larger code block with templated values."
+    'open-snippet': "Open your Snippets"
+    detail2: "In your snippets file, type <code>snip</code> then hit <code>tab</code>. The <code>snip</code> snippet will expand to create a snippet!"
+    note:
+      text1: "Next time:"
+      text2: " You can open your snippets in Menu &gt; File."
+      _template: "<strong>${text1}</strong>${text2}"
+  shortcuts:
+    title:
+      text1: "Learn "
+      text2: "Keyboard Shortcuts"
+      text3: ""        # optional
+      _template: "${text1}<span>${text2}</span>${text3}"
+    detail: 
+      text1: "If you only remember one keyboard shortcut make it "
+      text2: ". This keystroke toggles the command palette, which lists every Atom command.
+              It's a good way to learn more shortcuts. Yes, you can try it now!"
+      text3: "If you want to use these guides again use the command palette "
+      text4: " and search for "
+      text5: "Welcome"
+      text6: "."
+      _template: "<p>${text1}<kbd></kbd>${text2}</p><p>${text3}<kbd></kbd>${text4}<span>${text5}</span>${text6}</p>"

--- a/def/zh-tw/welcome.cson
+++ b/def/zh-tw/welcome.cson
@@ -1,29 +1,24 @@
 Welcome:
   tabTitle: "歡迎"
-  subtitle: {
+  subtitle:
     text1: "為 21 世紀打造 — 可改造的文字編輯器"
     superscript: ""
     text2: ""
-  }
-  help: {
+  help:
     forHelpVisit: "若需要協助，請造訪"
-    atomDocs: {
+    atomDocs:
       text1: ""
       link: "Atom 文件"
       text2: "以取得操作指南及 API 參考文件。"
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomForum: {
+    atomForum:
       text1: "Atom 論壇，位於 "
       link: "discuss.atom.io"
       text2: ""   # optional
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-    atomOrg: {
+    atomOrg:
       text1: ""
       link: "Atom 網站"
       text2: "。這裡包含所有 GitHub 所開發的 Atom 擴充套件。"
       _template: "${text1}<a>${link}</a>${text2}"
-    }
-  }
   showWelcomeGuide: "開啟 Atom 時顯示歡迎指南"

--- a/lib/consent.js
+++ b/lib/consent.js
@@ -1,0 +1,93 @@
+// "Telemetry Consent" view
+//
+// It has 3 views, which are "Welcom", "Welcome Guide" and "Telemetry Consent"
+
+module.exports = class Consent {
+  // inner: get the pane of "Consent Telemtry"
+  static getConsentPane() {
+    const pane = document.getElementsByClassName("welcome")
+    for (let elm of pane) {
+      // if (pane[i].classList.contains('is-guide')) { continue } // Guide
+      if (elm.getElementsByClassName("welcome-consent").length > 0) {
+        return elm
+      } // Consent
+      if (elm.getElementsByClassName("welcome-header").length > 0) {
+        continue
+      } // Welcome
+    }
+    return null
+  }
+
+  // inner
+  static updateConsent(pane) {
+    const consentTab = document.querySelector('.tab[data-type="ConsentView"]')
+    /* the pane that is not activated, can not be localized! So, the following codes are comment-out. 
+     * Also, "ConsentView" dose not include 'active', so the following codes are comment-out 
+    let consentEnabled
+    if (consentTab) { ConsentEnabled = consentTab.className.includes('active') }
+    if (!consentTab || !consentEnabled) { return } 
+    */
+    if (!consentTab) {
+      return
+    }
+    // Tab Title: "Telemetry Consent"
+    consentTab.querySelector(".title").textContent = this.defT.Consent.tabTitle
+    // const consent = document.querySelector('div.welcome>div.welcome-container') // can not traverse from document
+    // const consent = document.querySelector('div.welcome:not(.is-guide)')
+    const consent = this.getConsentPane()
+    if (!consent) {
+      return
+    }
+    if (consent.getAttribute("data-localized") !== "true") {
+      // Line #1: Help improve...
+      const desc = consent.querySelector("div.welcome-consent>p")
+      if (desc !== null) {
+        let {text1, text2, text3} = this.defT.Consent.desc
+        desc.innerHTML = `${text1}<strong>${text2}</strong>${text3}`
+      }
+      const chioceGroup = consent.getElementsByClassName("welcome-consent-choices")?.item(0) ?? null
+      if (chioceGroup !== null) {
+        // Line #2: Button
+        const btnsNodeList = chioceGroup.querySelectorAll('button[class="btn btn-primary"]')
+        btnsNodeList[0].textContent = this.defT.Consent.send["send-usage"]
+        btnsNodeList[1].textContent = this.defT.Consent.unsend["unsend-usage"]
+        // Line #3: Notes
+        const noteNodeList = chioceGroup.querySelectorAll("p.welcome-note")
+        let node = noteNodeList[0]
+        if (node !== null) {
+          const {text1, text2, text3} = this.defT.Consent.send.notes
+          node.childNodes[0].textContent = text1
+          node.childNodes[2].textContent = text2
+          node.childNodes[4].textContent = text3
+        }
+        node = noteNodeList[1]
+        if (node !== null) {
+          node.textContent = this.defT.Consent.unsend.notes
+        }
+      }
+      // Line #4: with Love by
+      const {with: _with, by} = this.defT.Consent
+      const loves = consent.querySelector("div.welcome-footer>p.welcome-love")
+      if (loves !== null) {
+        loves.childNodes[1].textContent = _with
+        loves.childNodes[3].textContent = by
+      }
+    }
+    return consent.setAttribute("data-localized", "true")
+  }
+
+  // call from main.js
+  static localize(defT) {
+    this.defT = defT
+    this.updateConsent(null) // first time localize
+    atom.workspace.onDidChangeActivePaneItem((item) => {
+      if (!item) {
+        return
+      }
+      if (item.constructor.name === "ConsentView") {
+        // 2nd time localize
+        return setTimeout(() => this.updateConsent(item), 0)
+      }
+    })
+  }
+}

--- a/lib/guide.js
+++ b/lib/guide.js
@@ -1,0 +1,204 @@
+// "Welcome Guide" view
+//
+// It has 3 views, which are "Welcom", "Welcome Guide" and "Telemetry Consent"
+
+module.exports = class Guide {
+  // inner: get the pane of "Welcome Guide"
+  static getGuidePane() {
+    const guide = document.getElementsByClassName("welcome is-guide").item(0)
+    if (guide) {
+      return guide
+    } // Guide
+    /* The following codes are not necessary! 
+     * Because document.getElementsByClassName('welcome') can not return <div classname="welcome is-guide">
+    const pane = document.getElementsByClassName('welcome')
+    for (let elm of pane) {
+        if (elm.classList.contains('is-guide')) { elm } // Guide, dose not work!
+        if (elm.getElementsByClassName('welcome-consent').length > 0) { continue } // Consent
+        if (elm.getElementsByClassName('welcome-header').length > 0) { continue } // Welcome
+    } */
+    return null
+  }
+
+  // inner
+  static updateGuide(pane) {
+    const guideTab = document.querySelector('.tab[data-type="GuideView"]')
+    // let guideEnabled
+    // if (guideTab) { guideEnabled = guideTab.className.includes('active') }
+    // if (!guideTab || guideEnabled) { return }
+    if (!guideTab) {
+      return
+    }
+    // Tab Title: "Welcome Guide"
+    guideTab.querySelector(".title").textContent = this.defG.Guide.tabTitle
+    // const consent = document.querySelector('div.welcome>div.welcome-container') // can not traverse from document
+    // const guide = document.querySelector('div.welcome.is-guide)')
+    const guide = this.getGuidePane()
+    if (!guide) {
+      return
+    }
+    if (guide.getAttribute("data-localized") !== "true") {
+      // Line #1: Sub-title
+      guide.querySelector("h1.welcome-title").textContent = this.defG.Guide.subTitle
+      // Line #2-#10: process 9 cards
+      const cardGroup = guide.getElementsByClassName("welcome-card")
+      for (let card of cardGroup) {
+        let section = card.getAttribute("data-section")
+        let summary = card.querySelector("summary.welcome-summary")
+        let deatil = card.getElementsByClassName("welcome-detail")?.item(0) ?? null
+        let note = card.getElementsByClassName("welcome-note")?.item(0) ?? null
+        let buttonList = card.querySelectorAll("button.btn.btn-primary")
+        switch (section) {
+          case "project": // Line #2: Project
+            {
+              const {text1, text2, text3} = this.defG.Guide.project.title
+              summary.childNodes[0].textContent = text1
+              summary.childNodes[1].textContent = text2
+              summary.appendChild(document.createTextNode(text3))
+            }
+            deatil.childNodes[1].textContent = this.defG.Guide.project.detail
+            buttonList.item(0).textContent = this.defG.Guide.project["open-project"]
+            {
+              const {text1, text2} = this.defG.Guide.project.note
+              note.innerHTML = `<strong>${text1}</strong>${text2}`
+            }
+            break
+          case "git": // Line #3: Git
+            {
+              const {text1, text2, text3} = this.defG.Guide.git.title
+              summary.childNodes[0].textContent = text1
+              summary.childNodes[2].textContent = text2
+              summary.appendChild(document.createTextNode(text3))
+            }
+            deatil.childNodes[1].textContent = this.defG.Guide.git.detail
+            buttonList.item(0).textContent = this.defG.Guide.git["open-git"]
+            buttonList.item(1).textContent = this.defG.Guide.git["open-github"]
+            {
+              const {text1, text2, text3} = this.defG.Guide.git.note
+              note.childNodes[0].textContent = text1
+              note.childNodes[1].textContent = text2
+              note.childNodes[3].textContent = text3
+            }
+            break
+          case "teletype": // Line #4: Teletype
+            {
+              const {text1, text2, text3} = this.defG.Guide.teletype.title
+              summary.childNodes[0].textContent = text1
+              summary.childNodes[2].textContent = text2
+              summary.appendChild(document.createTextNode(text3))
+            }
+            deatil.childNodes[1].textContent = this.defG.Guide.teletype.detail
+            buttonList.item(0).textContent = this.defG.Guide.teletype["install-teletype"]
+            break
+          case "packages": // Line #5: Package
+            {
+              const {text1, text2, text3} = this.defG.Guide.packages.title
+              summary.childNodes[0].textContent = text1
+              summary.childNodes[1].textContent = text2
+              summary.appendChild(document.createTextNode(text3))
+            }
+            deatil.childNodes[1].textContent = this.defG.Guide.packages.detail
+            buttonList.item(0).textContent = this.defG.Guide.packages["install-package"]
+            {
+              const {text1, text2} = this.defG.Guide.packages.note
+              note.innerHTML = `<strong>${text1}</strong>${text2}`
+            }
+            break
+          case "themes": // Line #6: Theme
+            {
+              const {text1, text2, text3} = this.defG.Guide.themes.title
+              summary.childNodes[0].textContent = text1
+              summary.childNodes[1].textContent = text2
+              summary.appendChild(document.createTextNode(text3))
+            }
+            deatil.childNodes[1].textContent = this.defG.Guide.themes.detail1
+            deatil.childNodes[3].textContent = this.defG.Guide.themes.detail2
+            buttonList.item(0).textContent = this.defG.Guide.themes["open-theme"]
+            {
+              const {text1, text2} = this.defG.Guide.themes.note
+              note.innerHTML = `<strong>${text1}</strong>${text2}`
+            }
+            break
+          case "styling": // Line #7: Styling
+            {
+              const {text1, text2, text3} = this.defG.Guide.styling.title
+              summary.childNodes[0].textContent = text1
+              summary.childNodes[1].textContent = text2
+              summary.appendChild(document.createTextNode(text3))
+            }
+            deatil.childNodes[1].textContent = this.defG.Guide.styling.detail1
+            deatil.childNodes[3].textContent = this.defG.Guide.styling.detail2
+            buttonList.item(0).textContent = this.defG.Guide.styling["open-stylesheet"]
+            {
+              const {text1, text2} = this.defG.Guide.styling.note
+              note.innerHTML = `<strong>${text1}</strong>${text2}`
+            }
+            break
+          case "init-script": // Line #8: Init Script
+            {
+              const {text1, text2, text3} = this.defG.Guide["init-script"].title
+              summary.childNodes[0].textContent = text1
+              summary.childNodes[1].textContent = text2
+              summary.appendChild(document.createTextNode(text3))
+            }
+            deatil.childNodes[1].textContent = this.defG.Guide["init-script"].detail1
+            deatil.childNodes[3].textContent = this.defG.Guide["init-script"].detail2
+            buttonList.item(0).textContent = this.defG.Guide["init-script"]["open-init-script"]
+            {
+              const {text1, text2} = this.defG.Guide["init-script"].note
+              note.innerHTML = `<strong>${text1}</strong>${text2}`
+            }
+            break
+          case "snippets": // Line #9: Snippets
+            {
+              const {text1, text2, text3} = this.defG.Guide.snippets.title
+              summary.childNodes[0].textContent = text1
+              summary.childNodes[1].textContent = text2
+              summary.appendChild(document.createTextNode(text3))
+            }
+            deatil.childNodes[1].textContent = this.defG.Guide.snippets.detail1
+            deatil.childNodes[3].innerHTML = this.defG.Guide.snippets.detail2 // for <code>
+            buttonList.item(0).textContent = this.defG.Guide.snippets["open-snippet"]
+            {
+              const {text1, text2} = this.defG.Guide.snippets.note
+              note.innerHTML = `<strong>${text1}</strong>${text2}`
+            }
+            break
+          case "shortcuts": // Line #10: Shortcuts
+            {
+              const {text1, text2, text3} = this.defG.Guide.shortcuts.title
+              summary.childNodes[0].textContent = text1
+              summary.childNodes[1].textContent = text2
+              summary.appendChild(document.createTextNode(text3))
+            }
+            {
+              const {text1, text2, text3, text4, text5, text6} = this.defG.Guide.shortcuts.detail
+              deatil.childNodes[1].childNodes[0].textContent = text1
+              deatil.childNodes[1].childNodes[3].textContent = text2
+              deatil.childNodes[2].childNodes[0].textContent = text3
+              deatil.childNodes[2].childNodes[4].textContent = text4
+              deatil.childNodes[2].childNodes[5].textContent = text5
+              deatil.childNodes[2].childNodes[6].textContent = text6
+            }
+            break
+        }
+      }
+    }
+    return guide.setAttribute("data-localized", "true")
+  }
+
+  // call from main.js
+  static localize(defG) {
+    this.defG = defG
+    this.updateGuide(null) // 1st time localize
+    atom.workspace.getCenter().onDidChangeActivePaneItem((item) => {
+      if (!item) {
+        return
+      }
+      if (item.constructor.name === "GuideView") {
+        // 2nd time localize
+        return setTimeout(() => this.updateGuide(item), 0)
+      }
+    })
+  }
+}

--- a/lib/welcome.js
+++ b/lib/welcome.js
@@ -1,85 +1,101 @@
-'use babel';
+// "Welcome" view
+//
+// It has 3 views, which are "Welcom", "Welcome Guide" and "Telemetry Consent"
 
-export default class Welcome {
-  static updateWelcome() {
-    let welcomeEnabled;
-    const welcomeTab = document.querySelector('.tab[data-type="WelcomeView"]');
-    if (welcomeTab) {
-      welcomeEnabled = welcomeTab.className.includes('active');
+module.exports = class Welcome {
+  // inner: get the pane of "Welcome"
+  static getWelcomePane() {
+    const pane = document.getElementsByClassName('welcome')
+    for (let elm of pane) {
+      // if (pane[i].classList.contains('is-guide')) { continue } // Guide
+      if (elm.getElementsByClassName('welcome-consent').length > 0) {
+        continue
+      } // Consent
+      if (elm.getElementsByClassName('welcome-header').length > 0) {
+        return elm
+      } // Welcome
     }
-    if (!welcomeTab || !welcomeEnabled) {
-      return;
-    }
-    welcomeTab.querySelector('.title').textContent = this.defW.Welcome.tabTitle;
+    return null
+  }
 
-    const welcome = document.querySelector('.welcome .welcome-container');
-    if (welcome === null) {
-      return;
+  // inner
+  static updateWelcome(pane) {
+    const welcomeTab = document.querySelector('.tab[data-type="WelcomeView"]')
+    /* the pane that is not activated, can not be localized! So, the following codes are comment-out. 
+    let welcomeEnabled
+    if (welcomeTab) { welcomeEnabled = welcomeTab.className.includes('active') }
+    if (!welcomeTab || !welcomeEnabled) { return }
+    */
+    if (!welcomeTab) {
+      return
+    }
+    // Tab Title: "Welcome"
+    welcomeTab.querySelector('.title').textContent = this.defW.Welcome.tabTitle
+    // const welcome = document.querySelector('.welcome .welcome-container')
+    const welcome = this.getWelcomePane()
+    if (!welcome) {
+      return
     }
     if (welcome.getAttribute('data-localized') !== 'true') {
       {
-        const subtitle = welcome.querySelector(
-          '.welcome-header h1.welcome-title',
-        );
+        const subtitle = welcome.querySelector('.welcome-header h1.welcome-title')
         if (subtitle) {
-          let { text1, superscript, text2 } = this.defW.Welcome.subtitle;
-          subtitle.innerHTML = `${text1}<sup>${superscript}</sup>${text2}`;
+          let {text1, superscript, text2} = this.defW.Welcome.subtitle
+          subtitle.innerHTML = `${text1}<sup>${superscript}</sup>${text2}`
         }
       }
-      const helpGroup = welcome.querySelector('.welcome-panel');
+      const helpGroup = welcome.querySelector('.welcome-panel')
       if (helpGroup) {
-        helpGroup.querySelector('p').textContent =
-          this.defW.Welcome.help.forHelpVisit;
+        helpGroup.querySelector('p').textContent = this.defW.Welcome.help.forHelpVisit
         {
-          const liDocs = helpGroup.querySelector('ul li:nth-child(1)');
+          const liDocs = helpGroup.querySelector('ul li:nth-child(1)')
           if (liDocs) {
-            const { text1, link, text2 } = this.defW.Welcome.help.atomDocs;
-            liDocs.childNodes[0].textContent = text1;
-            liDocs.childNodes[2].textContent = link;
-            liDocs.childNodes[4].textContent = text2;
+            const {text1, link, text2} = this.defW.Welcome.help.atomDocs
+            liDocs.childNodes[0].textContent = text1
+            liDocs.childNodes[2].textContent = link
+            liDocs.childNodes[4].textContent = text2
           }
         }
         {
-          const liForum = helpGroup.querySelector('ul li:nth-child(2)');
+          const liForum = helpGroup.querySelector('ul li:nth-child(2)')
           if (liForum) {
-            const { text1, link, text2 } = this.defW.Welcome.help.atomForum;
-            liForum.childNodes[0].textContent = text1;
-            liForum.childNodes[2].textContent = link;
-            liForum.lastChild.parentNode.appendChild(
-              document.createTextNode(text2),
-            );
+            const {text1, link, text2} = this.defW.Welcome.help.atomForum
+            liForum.childNodes[0].textContent = text1
+            liForum.childNodes[2].textContent = link
+            liForum.lastChild.parentNode.appendChild(document.createTextNode(text2))
           }
         }
         {
-          const liOrg = helpGroup.querySelector('ul li:nth-child(3)');
+          const liOrg = helpGroup.querySelector('ul li:nth-child(3)')
           if (liOrg) {
-            const { text1, link, text2 } = this.defW.Welcome.help.atomOrg;
-            liOrg.childNodes[0].textContent = text1;
-            liOrg.childNodes[2].textContent = link;
-            liOrg.childNodes[3].textContent = text2;
+            const {text1, link, text2} = this.defW.Welcome.help.atomOrg
+            liOrg.childNodes[0].textContent = text1
+            liOrg.childNodes[2].textContent = link
+            liOrg.childNodes[3].textContent = text2
           }
         }
       }
-      const label = welcome.querySelector('label');
+      const label = welcome.querySelector('label')
       if (label) {
         // Checkbox is the 1st [0] node; text label is the 2nd [1] node.
-        label.childNodes[1].textContent = this.defW.Welcome.showWelcomeGuide;
+        label.childNodes[1].textContent = this.defW.Welcome.showWelcomeGuide
       }
-
-      return welcome.setAttribute('data-localized', 'true');
+      return welcome.setAttribute('data-localized', 'true')
     }
   }
 
+  // call from main.js
   static localize(defW) {
-    this.defW = defW;
-    this.updateWelcome(); // first time localize
+    this.defW = defW
+    this.updateWelcome() // first time localize
     atom.workspace.onDidChangeActivePaneItem((item) => {
       if (!item) {
-        return;
+        return
       }
-      if (item.__proto__.constructor.name === 'WelcomeView') {
-        return setTimeout(() => this.updateWelcome(), 0);
+      if (item.constructor.name === 'WelcomeView') {
+        // 2nd time localize
+        return setTimeout(() => this.updateWelcome(), 0)
       }
-    });
+    })
   }
 }

--- a/spec/config.js
+++ b/spec/config.js
@@ -6,6 +6,8 @@ export const CSON_FILES = [
   'settings.cson',
   'about.cson',
   'welcome.cson',
+  'consent.cson',
+  'guide.cson'
 ];
 
 export const ATOM_VERSION = 'v1.22.0-beta0';


### PR DESCRIPTION
### Requirements for Contributing a Bug Fix

This fix enable `atom-i18n` to localize "Welcome Guide" and "Telemetry Consent" views.

### Identify the Bug

`atom-i18n` can not localize both "Welcome Guide" and "Telemetry Consent" views.

Those bugs are opened as the Issue [#319](https://github.com/liuderchi/atom-i18n/issues/319).


### Description of the Change

- add feature of localizing 'Welcome Guide' and 'Telemetry Consent' (so, you can localize them)
  - add 'consent.cson' and 'guide.cson' file to def/{template, <locale>}/ directory
  - localize 'consent.cson' and 'guide.cson' file in Japanese
  - add 'consent.cson' and 'guide.cson' specification to spec/config.js file
  - change def/*/welcome.cson from json format to cson format
  - add lib/{consent, guide}.js, and fix a minor bug of lib/welcome.js
- Also, end-of-line code of all files that are modified, are 'CRLF' (Windows format)
- The branch is `add/localize-welcome-views`


### Alternate Designs

None


### Possible Drawbacks

User might not be be able to change `telemetry consent` settings.


### Verification Process

1. All locale files, such as def/ja/welcome.cson, are tested with `npm run validation -- --locale`.
2. All locale files are tested on Atom editor with `atom-i18n`, by manually changing locale.


### Release Notes

- "Welcome Guide" and "Telemetry Consent" are able to be localized in your language.

